### PR TITLE
feat: change `Response.json` body to type `Object?`

### DIFF
--- a/packages/dart_frog/lib/src/response.dart
+++ b/packages/dart_frog/lib/src/response.dart
@@ -35,7 +35,7 @@ class Response {
   /// Create a [Response] with a json body.
   Response.json({
     int statusCode = 200,
-    Map<String, dynamic>? body = const <String, dynamic>{},
+    Object? body = const <String, dynamic>{},
     Map<String, String> headers = const <String, String>{},
   }) : this(
           statusCode: statusCode,


### PR DESCRIPTION
## Status

READY

## Description

Hello @felangel !
Thanks for this package, I've been waiting a long time for a convenient backend framework for dart.

I think that the body field of Response.json should be typed [Object?]
As an example, my legacy project uses a List response like in [jsonplaceholder example](https://jsonplaceholder.typicode.com/users)

Maybe only Map<String, dynamic>? has some hidden meaning that I didn't know?

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
