### PR TITLE
docs: replace duplicate roadmap link in footer

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -80,10 +80,6 @@ const config = {
                 label: 'Basics',
                 to: '/docs/category/basics-',
               },
-              {
-                label: 'Roadmap',
-                to: '/docs/roadmap',
-              },
             ],
           },
           {
@@ -99,7 +95,7 @@ const config = {
               },
               {
                 label: 'Roadmap',
-                href: 'https://github.com/VeryGoodOpenSource/dart_frog/blob/main/ROADMAP.md',
+                href: '/docs/roadmap',
               },
             ],
           },

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -80,6 +80,10 @@ const config = {
                 label: 'Basics',
                 to: '/docs/category/basics-',
               },
+              {
+                label: 'Roadmap',
+                href: '/docs/roadmap',
+              },
             ],
           },
           {
@@ -94,8 +98,8 @@ const config = {
                 href: 'https://youtu.be/N7l0b09c6DA',
               },
               {
-                label: 'Roadmap',
-                href: '/docs/roadmap',
+                label: 'Package of the Week',
+                href: 'https://youtu.be/qjA0JFiPMnQ',
               },
             ],
           },

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -82,7 +82,7 @@ const config = {
               },
               {
                 label: 'Roadmap',
-                href: '/docs/roadmap',
+                to: '/docs/roadmap',
               },
             ],
           },


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

In the footer of the docs site:
- Remove the roadmap link in the "docs" section
- Point the roadmap link in the "resources" section to the correct page

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
