### PR TITLE
test(examples/todos): update test description to use correct status code

### DIFF
--- a/examples/todos/test/routes/todos/[id]_test.dart
+++ b/examples/todos/test/routes/todos/[id]_test.dart
@@ -129,7 +129,7 @@ void main() {
   });
 
   group('DELETE /todos/[id]', () {
-    test('responds with a 202 and deletes the todo', () async {
+    test('responds with a 204 and deletes the todo', () async {
       when(() => dataSource.read(any())).thenAnswer((_) async => todo);
       when(() => dataSource.delete(any())).thenAnswer((_) async => {});
       when(() => request.method).thenReturn(HttpMethod.delete);


### PR DESCRIPTION
**This commit resolves** #310 

## Status

**READY**

## Description

The test description for the `examples/todos` app inside the `test/routes/todos/[id]_test.dart` should be

```dart
test('responds with a 204 and deletes the todo', () async { 
```

instead of

```dart
test('responds with a 202 and deletes the todo', () async { 
```

as `HttpStatus.noContent` represents the `statusCode` of 204.

https://github.com/VeryGoodOpenSource/dart_frog/blob/5dd17bd3076dabd05fff036a59f5f9f295605621/examples/todos/test/routes/todos/%5Bid%5D_test.dart#L131-L132

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore