### PR TITLE
fix(dart_frog_cli): ensures usage is shown on invalid flags

### DIFF
--- a/packages/dart_frog_cli/lib/src/command_runner.dart
+++ b/packages/dart_frog_cli/lib/src/command_runner.dart
@@ -50,8 +50,14 @@ class DartFrogCommandRunner extends CommandRunner<int> {
 
   @override
   Future<int> run(Iterable<String> args) async {
-    final argResults = parse(args);
+    late final ArgResults argResults;
     late final int exitCode;
+    try {
+      argResults = parse(args);
+    } on UsageException catch (error) {
+      _logger.err('$error');
+      return ExitCode.usage.code;
+    }
 
     _sigint.watch().listen(_onSigint);
 

--- a/packages/dart_frog_cli/test/src/command_runner_test.dart
+++ b/packages/dart_frog_cli/test/src/command_runner_test.dart
@@ -82,6 +82,18 @@ void main() {
     });
 
     group('run', () {
+      test('ensures usage is shown on invalid flags', () async {
+        final exitCode = await commandRunner.run(['--bogus-flag']);
+        expect(exitCode, ExitCode.usage.code);
+        verify(
+          () => logger.err(
+            any(
+              that: startsWith('Could not find an option named "bogus-flag".'),
+            ),
+          ),
+        );
+      });
+
       test('checks for updates on sigint', () async {
         final exitCalls = <int>[];
         commandRunner = DartFrogCommandRunner(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

This PR handles invalid flags and displays the usage properly. Previously, the parsing of arguments would not catch errors and the usage would have been shown by throwing an exception which also displayed the stacktrace (see below).

![image](https://user-images.githubusercontent.com/7662016/198897207-d862df51-51f4-48dd-9847-7eed542c7e9f.png)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
