### PR TITLE
fix(mason_cli): update silently fails when the sdk is incompatible

### DIFF
--- a/packages/dart_frog_cli/lib/src/commands/update/update.dart
+++ b/packages/dart_frog_cli/lib/src/commands/update/update.dart
@@ -59,7 +59,7 @@ class UpdateCommand extends Command<int> {
     }
     if (result.exitCode != ExitCode.success.code) {
       updateProgress.fail();
-      _logger.err('Error updating Very Good CLI: ${result.stderr}');
+      _logger.err('Error updating Dart Frog CLI: ${result.stderr}');
       return ExitCode.software.code;
     }
     updateProgress.complete('Updated to $latestVersion');

--- a/packages/dart_frog_cli/lib/src/commands/update/update.dart
+++ b/packages/dart_frog_cli/lib/src/commands/update/update.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:args/command_runner.dart';
 import 'package:dart_frog_cli/src/command_runner.dart';
 import 'package:dart_frog_cli/src/version.dart';
@@ -44,11 +46,20 @@ class UpdateCommand extends Command<int> {
     }
 
     final updateProgress = _logger.progress('Updating to $latestVersion');
+    late ProcessResult result;
     try {
-      await _pubUpdater.update(packageName: packageName);
+      result = await _pubUpdater.update(
+        packageName: packageName,
+        versionConstraint: latestVersion,
+      );
     } catch (error) {
       updateProgress.fail();
       _logger.err('$error');
+      return ExitCode.software.code;
+    }
+    if (result.exitCode != ExitCode.success.code) {
+      updateProgress.fail();
+      _logger.err('Error updating Very Good CLI: ${result.stderr}');
       return ExitCode.software.code;
     }
     updateProgress.complete('Updated to $latestVersion');

--- a/packages/dart_frog_cli/pubspec.yaml
+++ b/packages/dart_frog_cli/pubspec.yaml
@@ -14,9 +14,7 @@ dependencies:
   mason: ^0.1.0-dev.39
   meta: ^1.7.0
   path: ^1.8.1
-  pub_updater:
-    git:
-      url: https://github.com/VeryGoodOpenSource/pub_updater
+  pub_updater: ^0.2.4
   pubspec_parse: ^1.2.0
   stream_transform: ^2.0.0
   watcher: ^1.0.1

--- a/packages/dart_frog_cli/pubspec.yaml
+++ b/packages/dart_frog_cli/pubspec.yaml
@@ -14,7 +14,9 @@ dependencies:
   mason: ^0.1.0-dev.39
   meta: ^1.7.0
   path: ^1.8.1
-  pub_updater: ^0.2.2
+  pub_updater:
+    git:
+      url: https://github.com/VeryGoodOpenSource/pub_updater
   pubspec_parse: ^1.2.0
   stream_transform: ^2.0.0
   watcher: ^1.0.1

--- a/packages/dart_frog_cli/test/src/commands/update/update_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/update/update_test.dart
@@ -83,12 +83,12 @@ void main() {
     });
 
     test('handles pub update process errors', () async {
+      const error = 'Oh no! Installing this is not possible right now!';
       when(() => processResult.exitCode).thenReturn(1);
-
-      when<dynamic>(() => processResult.stderr)
-          .thenReturn('Oh no! Installing this is not possible right now!');
-      when(() => pubUpdater.getLatestVersion(any()))
-          .thenAnswer((_) async => latestVersion);
+      when<dynamic>(() => processResult.stderr).thenReturn(error);
+      when(
+        () => pubUpdater.getLatestVersion(any()),
+      ).thenAnswer((_) async => latestVersion);
       when(
         () => pubUpdater.update(
           packageName: any(named: 'packageName'),
@@ -99,11 +99,7 @@ void main() {
       final result = await command.run();
       expect(result, equals(ExitCode.software.code));
       verify(() => logger.progress('Checking for updates')).called(1);
-      verify(
-        () => logger.err(
-          '''Error updating Dart Frog CLI: Oh no! Installing this is not possible right now!''',
-        ),
-      );
+      verify(() => logger.err('''Error updating Dart Frog CLI: $error'''));
       verify(
         () => pubUpdater.update(
           packageName: any(named: 'packageName'),

--- a/packages/dart_frog_cli/test/src/commands/update/update_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/update/update_test.dart
@@ -101,7 +101,7 @@ void main() {
       verify(() => logger.progress('Checking for updates')).called(1);
       verify(
         () => logger.err(
-          '''Error updating Very Good CLI: Oh no! Installing this is not possible right now!''',
+          '''Error updating Dart Frog CLI: Oh no! Installing this is not possible right now!''',
         ),
       );
       verify(

--- a/packages/dart_frog_cli/test/src/commands/update/update_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/update/update_test.dart
@@ -99,7 +99,7 @@ void main() {
       final result = await command.run();
       expect(result, equals(ExitCode.software.code));
       verify(() => logger.progress('Checking for updates')).called(1);
-      verify(() => logger.err('''Error updating Dart Frog CLI: $error'''));
+      verify(() => logger.err('Error updating Dart Frog CLI: $error'));
       verify(
         () => pubUpdater.update(
           packageName: any(named: 'packageName'),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

fix: update silently fails when the SDK doesn't support the most recent version fo the cli


depends on a new version of the pub updater: https://github.com/VeryGoodOpenSource/pub_updater/pull/37


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
