### PR TITLE
fix: url in "custom_init_method" doc

### DIFF
--- a/docs/docs/advanced/custom_init_method.md
+++ b/docs/docs/advanced/custom_init_method.md
@@ -5,14 +5,14 @@ title: 🛫 Custom Init Method
 
 # Custom Init Method 🛫
 
-Dart Frog supports creating a custom entrypoint as shown in the [Custom Entrypoint docs](docs/advanced/custom_entrypoint) but that will run every time the server hot reloads. In cases where you want to initialize something only on server start, like setting up a database connection, you can use the `init` method.
+Dart Frog supports creating a custom entrypoint as shown in the [Custom Entrypoint docs](/docs/advanced/custom_entrypoint) but that will run every time the server hot reloads. In cases where you want to initialize something only on server start, like setting up a database connection, you can use the `init` method.
 
 ## Creating a Custom Init Method ✨
 
 To create a custom init method, simply create a `main.dart` file at the root of your Dart Frog project.
 
 :::warning
-Keep in mind that the `main.dart` file must expose a top-level `run` as mentioned in the [Custom Entrypoint docs](docs/advanced/custom_entrypoint).
+Keep in mind that the `main.dart` file must expose a top-level `run` as mentioned in the [Custom Entrypoint docs](/docs/advanced/custom_entrypoint).
 :::
 
 Add the following top-level `init` method to the `main.dart` file:


### PR DESCRIPTION
## Status

READY

## Description

It was missing a `/` in URLs

## Type of Change


- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
