### PR TITLE
fix(dart_frog): `Response.json()` overwrites `content-type` header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.vscode/settings.json

--- a/packages/dart_frog/lib/src/response.dart
+++ b/packages/dart_frog/lib/src/response.dart
@@ -54,8 +54,9 @@ class Response {
           statusCode: statusCode,
           body: body != null ? jsonEncode(body) : null,
           headers: {
-            HttpHeaders.contentTypeHeader: ContentType.json.value,
             ...headers,
+            if (!headers.containsKey(HttpHeaders.contentTypeHeader))
+              HttpHeaders.contentTypeHeader: ContentType.json.value,
           },
         );
 
@@ -76,8 +77,7 @@ class Response {
   /// Returns a [Future] containing the body as a [String].
   Future<String> body() async {
     const responseBodyKey = 'dart_frog.response.body';
-    final bodyFromContext =
-        _response.context[responseBodyKey] as Completer<String>?;
+    final bodyFromContext = _response.context[responseBodyKey] as Completer<String>?;
     if (bodyFromContext != null) return bodyFromContext.future;
 
     final completer = Completer<String>();

--- a/packages/dart_frog/lib/src/response.dart
+++ b/packages/dart_frog/lib/src/response.dart
@@ -54,8 +54,8 @@ class Response {
           statusCode: statusCode,
           body: body != null ? jsonEncode(body) : null,
           headers: {
-            ...headers,
             HttpHeaders.contentTypeHeader: ContentType.json.value,
+            ...headers,
           },
         );
 

--- a/packages/dart_frog/lib/src/response.dart
+++ b/packages/dart_frog/lib/src/response.dart
@@ -77,7 +77,8 @@ class Response {
   /// Returns a [Future] containing the body as a [String].
   Future<String> body() async {
     const responseBodyKey = 'dart_frog.response.body';
-    final bodyFromContext = _response.context[responseBodyKey] as Completer<String>?;
+    final bodyFromContext =
+        _response.context[responseBodyKey] as Completer<String>?;
     if (bodyFromContext != null) return bodyFromContext.future;
 
     final completer = Completer<String>();

--- a/packages/dart_frog/test/src/response_test.dart
+++ b/packages/dart_frog/test/src/response_test.dart
@@ -184,6 +184,17 @@ void main() {
         final response = Response.json();
         expect(response.json(), completion(isEmpty));
       });
+
+      test('has correct content-type when overriden in headers', () {
+        final headers = <String, String>{
+          HttpHeaders.contentTypeHeader: ContentType.html.value,
+        };
+        final response = Response.json(headers: headers);
+        expect(
+          response.headers[HttpHeaders.contentTypeHeader],
+          equals(ContentType.html.value),
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
<!--
Fixes #593
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->
Fixes the bug that didn't allow overriding content-type headers when using `Response.json()` constructor

Closes #593 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
