### PR TITLE
feat(dart_frog_gen)!: reland "add route configuration validation to gen"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .vscode/settings.json
+.DS_Store

--- a/packages/dart_frog_gen/lib/dart_frog_gen.dart
+++ b/packages/dart_frog_gen/lib/dart_frog_gen.dart
@@ -2,3 +2,4 @@
 library dart_frog_gen;
 
 export 'src/build_route_configuration.dart';
+export 'src/validate_route_configuration/validate_route_configuration.dart';

--- a/packages/dart_frog_gen/lib/src/validate_route_configuration/external_path_dependencies.dart
+++ b/packages/dart_frog_gen/lib/src/validate_route_configuration/external_path_dependencies.dart
@@ -9,7 +9,7 @@ typedef OnExternalPathDependency = void Function(
   String dependencyPath,
 );
 
-/// Reports existence of external path dependencies on a [Directory].
+/// Reports existence of external path dependencies on a [io.Directory].
 Future<void> reportExternalPathDependencies(
   io.Directory directory, {
   /// Callback called when any external path dependency is found.

--- a/packages/dart_frog_gen/lib/src/validate_route_configuration/external_path_dependencies.dart
+++ b/packages/dart_frog_gen/lib/src/validate_route_configuration/external_path_dependencies.dart
@@ -1,0 +1,49 @@
+import 'dart:io' as io;
+
+import 'package:path/path.dart' as path;
+import 'package:pubspec_parse/pubspec_parse.dart';
+
+/// Type definition for callbacks that report external path dependencies.
+typedef OnExternalPathDependency = void Function(
+  String dependencyName,
+  String dependencyPath,
+);
+
+/// Reports existence of external path dependencies on a [Directory].
+Future<void> reportExternalPathDependencies(
+  io.Directory directory, {
+  /// Callback called when any external path dependency is found.
+  void Function()? onViolationStart,
+
+  /// Callback called for each external path dependency found.
+  OnExternalPathDependency? onExternalPathDependency,
+
+  /// Callback called when any external path dependency is found.
+  void Function()? onViolationEnd,
+}) async {
+  final pubspec = Pubspec.parse(
+    await io.File(path.join(directory.path, 'pubspec.yaml')).readAsString(),
+  );
+
+  final dependencies = pubspec.dependencies;
+  final devDependencies = pubspec.devDependencies;
+  final pathDependencies = [...dependencies.entries, ...devDependencies.entries]
+      .where((entry) => entry.value is PathDependency)
+      .map((entry) {
+    final value = entry.value as PathDependency;
+    return [entry.key, value.path];
+  }).toList();
+  final externalDependencies = pathDependencies.where(
+    (dep) => !path.isWithin(directory.path, dep.last),
+  );
+
+  if (externalDependencies.isNotEmpty) {
+    onViolationStart?.call();
+    for (final dependency in externalDependencies) {
+      final dependencyName = dependency.first;
+      final dependencyPath = path.normalize(dependency.last);
+      onExternalPathDependency?.call(dependencyName, dependencyPath);
+    }
+    onViolationEnd?.call();
+  }
+}

--- a/packages/dart_frog_gen/lib/src/validate_route_configuration/rogue_routes.dart
+++ b/packages/dart_frog_gen/lib/src/validate_route_configuration/rogue_routes.dart
@@ -1,0 +1,33 @@
+import 'package:dart_frog_gen/dart_frog_gen.dart';
+import 'package:path/path.dart' as path;
+
+/// Type definition for callbacks that report rogue routes.
+typedef OnRogueRoute = void Function(String filePath, String idealPath);
+
+/// Reports existence of rogue routes on a [RouteConfiguration].
+void reportRogueRoutes(
+  RouteConfiguration configuration, {
+  /// Callback called when any rogue route is found.
+  void Function()? onViolationStart,
+
+  /// Callback called for each rogue route found.
+  OnRogueRoute? onRogueRoute,
+
+  /// Callback called when any rogue route is found.
+  void Function()? onViolationEnd,
+}) {
+  if (configuration.rogueRoutes.isNotEmpty) {
+    onViolationStart?.call();
+    for (final route in configuration.rogueRoutes) {
+      final filePath = path.normalize(path.join('routes', route.path));
+      final fileDirectory = path.dirname(filePath);
+      final idealPath = path.join(
+        fileDirectory,
+        path.basenameWithoutExtension(filePath),
+        'index.dart',
+      );
+      onRogueRoute?.call(filePath, idealPath);
+    }
+    onViolationEnd?.call();
+  }
+}

--- a/packages/dart_frog_gen/lib/src/validate_route_configuration/route_conflicts.dart
+++ b/packages/dart_frog_gen/lib/src/validate_route_configuration/route_conflicts.dart
@@ -1,0 +1,42 @@
+import 'package:dart_frog_gen/dart_frog_gen.dart';
+import 'package:path/path.dart' as path;
+
+/// Type definition for callbacks that report route conflicts.
+typedef OnRouteConflict = void Function(
+  String originalFilePath,
+  String conflictingFilePath,
+  String conflictingEndpoint,
+);
+
+/// Reports existence of route conflicts on a [RouteConfiguration].
+void reportRouteConflicts(
+  RouteConfiguration configuration, {
+  /// Callback called when any route conflict is found.
+  void Function()? onViolationStart,
+
+  /// Callback called for each route conflict found.
+  OnRouteConflict? onRouteConflict,
+
+  /// Callback called when any route conflict is found.
+  void Function()? onViolationEnd,
+}) {
+  final conflictingEndpoints =
+      configuration.endpoints.entries.where((entry) => entry.value.length > 1);
+  if (conflictingEndpoints.isNotEmpty) {
+    onViolationStart?.call();
+    for (final conflict in conflictingEndpoints) {
+      final originalFilePath = path.normalize(
+        path.join('routes', conflict.value.first.path),
+      );
+      final conflictingFilePath = path.normalize(
+        path.join('routes', conflict.value.last.path),
+      );
+      onRouteConflict?.call(
+        originalFilePath,
+        conflictingFilePath,
+        conflict.key,
+      );
+    }
+    onViolationEnd?.call();
+  }
+}

--- a/packages/dart_frog_gen/lib/src/validate_route_configuration/validate_route_configuration.dart
+++ b/packages/dart_frog_gen/lib/src/validate_route_configuration/validate_route_configuration.dart
@@ -1,0 +1,3 @@
+export 'external_path_dependencies.dart';
+export 'rogue_routes.dart';
+export 'route_conflicts.dart';

--- a/packages/dart_frog_gen/pubspec.yaml
+++ b/packages/dart_frog_gen/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 
 dependencies:
   path: ^1.8.1
+  pubspec_parse: ^1.2.2
 
 dev_dependencies:
   mocktail: ^0.3.0

--- a/packages/dart_frog_gen/test/src/validate_route_configuration/external_path_dependencies_test.dart
+++ b/packages/dart_frog_gen/test/src/validate_route_configuration/external_path_dependencies_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:dart_frog_gen/dart_frog_gen.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+void main() {
+  group('reportExternalPathDependencies', () {
+    late bool violationStartCalled;
+    late bool violationEndCalled;
+    late List<String> externalPathDependencies;
+
+    setUp(() {
+      violationStartCalled = false;
+      violationEndCalled = false;
+      externalPathDependencies = [];
+    });
+
+    test('reports nothing when there are no external path dependencies',
+        () async {
+      final directory = Directory.systemTemp.createTempSync();
+      File(path.join(directory.path, 'pubspec.yaml')).writeAsStringSync(
+        '''
+name: example
+version: 0.1.0
+environment:
+  sdk: ^2.17.0
+dependencies:
+  mason: any
+dev_dependencies:
+  test: any
+''',
+      );
+
+      await expectLater(
+        reportExternalPathDependencies(
+          directory,
+          onViolationStart: () {
+            violationStartCalled = true;
+          },
+          onViolationEnd: () {
+            violationEndCalled = true;
+          },
+          onExternalPathDependency: (_, dependencyPath) {
+            externalPathDependencies.add(dependencyPath);
+          },
+        ),
+        completes,
+      );
+
+      expect(violationStartCalled, isFalse);
+      expect(violationEndCalled, isFalse);
+      expect(externalPathDependencies, isEmpty);
+    });
+
+    test('reports when there is a single external path dependency', () async {
+      final directory = Directory.systemTemp.createTempSync();
+      File(path.join(directory.path, 'pubspec.yaml')).writeAsStringSync(
+        '''
+name: example
+version: 0.1.0
+environment:
+  sdk: ^2.17.0
+dependencies:
+  mason: any
+  foo:
+    path: ../../foo
+dev_dependencies:
+  test: any
+''',
+      );
+
+      await expectLater(
+        reportExternalPathDependencies(
+          directory,
+          onViolationStart: () {
+            violationStartCalled = true;
+          },
+          onViolationEnd: () {
+            violationEndCalled = true;
+          },
+          onExternalPathDependency: (_, dependencyPath) {
+            externalPathDependencies.add(dependencyPath);
+          },
+        ),
+        completes,
+      );
+
+      expect(violationStartCalled, isTrue);
+      expect(violationEndCalled, isTrue);
+      expect(externalPathDependencies, ['../../foo']);
+
+      directory.delete(recursive: true).ignore();
+    });
+
+    test('reports when there are multiple external path dependencies',
+        () async {
+      final directory = Directory.systemTemp.createTempSync();
+      File(path.join(directory.path, 'pubspec.yaml')).writeAsStringSync(
+        '''
+name: example
+version: 0.1.0
+environment:
+  sdk: ^2.17.0
+dependencies:
+  mason: any
+  foo:
+    path: ../../foo
+dev_dependencies:
+  test: any
+  bar:
+    path: ../../bar
+''',
+      );
+      await expectLater(
+        reportExternalPathDependencies(
+          directory,
+          onViolationStart: () {
+            violationStartCalled = true;
+          },
+          onViolationEnd: () {
+            violationEndCalled = true;
+          },
+          onExternalPathDependency: (_, dependencyPath) {
+            externalPathDependencies.add(dependencyPath);
+          },
+        ),
+        completes,
+      );
+
+      expect(violationStartCalled, isTrue);
+      expect(violationEndCalled, isTrue);
+      expect(externalPathDependencies, ['../../foo', '../../bar']);
+
+      directory.delete(recursive: true).ignore();
+    });
+  });
+}

--- a/packages/dart_frog_gen/test/src/validate_route_configuration/external_path_dependencies_test.dart
+++ b/packages/dart_frog_gen/test/src/validate_route_configuration/external_path_dependencies_test.dart
@@ -41,8 +41,8 @@ dev_dependencies:
           onViolationEnd: () {
             violationEndCalled = true;
           },
-          onExternalPathDependency: (_, dependencyPath) {
-            externalPathDependencies.add(dependencyPath);
+          onExternalPathDependency: (dependencyName, _) {
+            externalPathDependencies.add(dependencyName);
           },
         ),
         completes,
@@ -79,8 +79,8 @@ dev_dependencies:
           onViolationEnd: () {
             violationEndCalled = true;
           },
-          onExternalPathDependency: (_, dependencyPath) {
-            externalPathDependencies.add(dependencyPath);
+          onExternalPathDependency: (dependencyName, _) {
+            externalPathDependencies.add(dependencyName);
           },
         ),
         completes,
@@ -88,7 +88,7 @@ dev_dependencies:
 
       expect(violationStartCalled, isTrue);
       expect(violationEndCalled, isTrue);
-      expect(externalPathDependencies, ['../../foo']);
+      expect(externalPathDependencies, ['foo']);
 
       directory.delete(recursive: true).ignore();
     });
@@ -121,8 +121,8 @@ dev_dependencies:
           onViolationEnd: () {
             violationEndCalled = true;
           },
-          onExternalPathDependency: (_, dependencyPath) {
-            externalPathDependencies.add(dependencyPath);
+          onExternalPathDependency: (dependencyName, _) {
+            externalPathDependencies.add(dependencyName);
           },
         ),
         completes,
@@ -130,7 +130,7 @@ dev_dependencies:
 
       expect(violationStartCalled, isTrue);
       expect(violationEndCalled, isTrue);
-      expect(externalPathDependencies, ['../../foo', '../../bar']);
+      expect(externalPathDependencies, ['foo', 'bar']);
 
       directory.delete(recursive: true).ignore();
     });

--- a/packages/dart_frog_gen/test/src/validate_route_configuration/rogue_routes_test.dart
+++ b/packages/dart_frog_gen/test/src/validate_route_configuration/rogue_routes_test.dart
@@ -1,0 +1,114 @@
+import 'package:dart_frog_gen/dart_frog_gen.dart';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class _MockRouteConfiguration extends Mock implements RouteConfiguration {}
+
+void main() {
+  group('reportRogueRoutes', () {
+    late RouteConfiguration configuration;
+
+    late bool violationStartCalled;
+    late bool violationEndCalled;
+    late List<String> rogueRoutes;
+
+    setUp(() {
+      configuration = _MockRouteConfiguration();
+
+      violationStartCalled = false;
+      violationEndCalled = false;
+      rogueRoutes = [];
+    });
+
+    test('reports nothing when there are no rogue routes', () {
+      when(() => configuration.rogueRoutes).thenReturn([]);
+
+      reportRogueRoutes(
+        configuration,
+        onViolationStart: () {
+          violationStartCalled = true;
+        },
+        onRogueRoute: (filePath, idealPath) {
+          rogueRoutes.add(filePath);
+        },
+        onViolationEnd: () {
+          violationEndCalled = true;
+        },
+      );
+
+      expect(violationStartCalled, isFalse);
+      expect(violationEndCalled, isFalse);
+      expect(rogueRoutes, isEmpty);
+    });
+
+    test('reports single rogue route', () {
+      when(() => configuration.rogueRoutes).thenReturn(
+        const [
+          RouteFile(
+            name: 'hello',
+            path: 'hello.dart',
+            route: '/hello',
+            params: [],
+          ),
+        ],
+      );
+
+      reportRogueRoutes(
+        configuration,
+        onViolationStart: () {
+          violationStartCalled = true;
+        },
+        onRogueRoute: (filePath, idealPath) {
+          rogueRoutes.add(filePath);
+        },
+        onViolationEnd: () {
+          violationEndCalled = true;
+        },
+      );
+
+      expect(violationStartCalled, isTrue);
+      expect(violationEndCalled, isTrue);
+      expect(rogueRoutes, ['routes/hello.dart']);
+    });
+
+    test('reports multiple rogue routes', () {
+      when(() => configuration.rogueRoutes).thenReturn(
+        const [
+          RouteFile(
+            name: 'hello',
+            path: 'hello.dart',
+            route: '/hello',
+            params: [],
+          ),
+          RouteFile(
+            name: 'hi',
+            path: 'hi.dart',
+            route: '/hi',
+            params: [],
+          ),
+        ],
+      );
+
+      reportRogueRoutes(
+        configuration,
+        onViolationStart: () {
+          violationStartCalled = true;
+        },
+        onRogueRoute: (filePath, idealPath) {
+          rogueRoutes.add(filePath);
+        },
+        onViolationEnd: () {
+          violationEndCalled = true;
+        },
+      );
+
+      expect(violationStartCalled, isTrue);
+      expect(violationEndCalled, isTrue);
+      expect(rogueRoutes, [
+        'routes/hello.dart',
+        'routes/hi.dart',
+      ]);
+    });
+  });
+}

--- a/packages/dart_frog_gen/test/src/validate_route_configuration/rogue_routes_test.dart
+++ b/packages/dart_frog_gen/test/src/validate_route_configuration/rogue_routes_test.dart
@@ -1,6 +1,6 @@
 import 'package:dart_frog_gen/dart_frog_gen.dart';
-
 import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 class _MockRouteConfiguration extends Mock implements RouteConfiguration {}
@@ -69,7 +69,7 @@ void main() {
 
       expect(violationStartCalled, isTrue);
       expect(violationEndCalled, isTrue);
-      expect(rogueRoutes, ['routes/hello.dart']);
+      expect(rogueRoutes, [p.join('routes', 'hello.dart')]);
     });
 
     test('reports multiple rogue routes', () {
@@ -106,8 +106,8 @@ void main() {
       expect(violationStartCalled, isTrue);
       expect(violationEndCalled, isTrue);
       expect(rogueRoutes, [
-        'routes/hello.dart',
-        'routes/hi.dart',
+        p.join('routes', 'hello.dart'),
+        p.join('routes', 'hi.dart'),
       ]);
     });
   });

--- a/packages/dart_frog_gen/test/src/validate_route_configuration/route_conflicts_test.dart
+++ b/packages/dart_frog_gen/test/src/validate_route_configuration/route_conflicts_test.dart
@@ -120,8 +120,8 @@ void main() {
         },
       );
 
-      expect(violationStartCalled, isFalse);
-      expect(violationEndCalled, isFalse);
+      expect(violationStartCalled, isTrue);
+      expect(violationEndCalled, isTrue);
       expect(conflicts, ['/hello']);
     });
 
@@ -180,8 +180,8 @@ void main() {
         },
       );
 
-      expect(violationStartCalled, isFalse);
-      expect(violationEndCalled, isFalse);
+      expect(violationStartCalled, isTrue);
+      expect(violationEndCalled, isTrue);
       expect(conflicts, ['/hello', '/echo']);
     });
   });

--- a/packages/dart_frog_gen/test/src/validate_route_configuration/route_conflicts_test.dart
+++ b/packages/dart_frog_gen/test/src/validate_route_configuration/route_conflicts_test.dart
@@ -1,0 +1,188 @@
+import 'package:dart_frog_gen/dart_frog_gen.dart';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class _MockRouteConfiguration extends Mock implements RouteConfiguration {}
+
+void main() {
+  group('reportRouteConflicts', () {
+    late RouteConfiguration configuration;
+
+    late bool violationStartCalled;
+    late bool violationEndCalled;
+    late List<String> conflicts;
+
+    setUp(() {
+      configuration = _MockRouteConfiguration();
+
+      violationStartCalled = false;
+      violationEndCalled = false;
+      conflicts = [];
+    });
+
+    test('reports nothing when there are no endpoints', () {
+      when(() => configuration.endpoints).thenReturn({});
+
+      reportRouteConflicts(
+        configuration,
+        onViolationStart: () {
+          violationStartCalled = true;
+        },
+        onRouteConflict: (_, __, conflictingEndpoint) {
+          conflicts.add(conflictingEndpoint);
+        },
+        onViolationEnd: () {
+          violationEndCalled = true;
+        },
+      );
+
+      expect(violationStartCalled, isFalse);
+      expect(violationEndCalled, isFalse);
+      expect(conflicts, isEmpty);
+    });
+
+    test('reports nothing when there are endpoints and no conflicts', () {
+      when(() => configuration.endpoints).thenReturn({
+        '/': const [
+          RouteFile(
+            name: 'index',
+            path: 'index.dart',
+            route: '/',
+            params: [],
+          ),
+        ],
+        '/hello': const [
+          RouteFile(
+            name: 'hello',
+            path: 'hello.dart',
+            route: '/hello',
+            params: [],
+          )
+        ]
+      });
+
+      reportRouteConflicts(
+        configuration,
+        onViolationStart: () {
+          violationStartCalled = true;
+        },
+        onRouteConflict: (_, __, conflictingEndpoint) {
+          conflicts.add(conflictingEndpoint);
+        },
+        onViolationEnd: () {
+          violationEndCalled = true;
+        },
+      );
+
+      expect(violationStartCalled, isFalse);
+      expect(violationEndCalled, isFalse);
+      expect(conflicts, isEmpty);
+    });
+
+    test('reports single conflict when there is one endpoint with conflicts',
+        () {
+      when(() => configuration.endpoints).thenReturn({
+        '/': const [
+          RouteFile(
+            name: 'index',
+            path: 'index.dart',
+            route: '/',
+            params: [],
+          ),
+        ],
+        '/hello': const [
+          RouteFile(
+            name: 'hello',
+            path: 'hello.dart',
+            route: '/hello',
+            params: [],
+          ),
+          RouteFile(
+            name: 'hello_index',
+            path: 'hello/index.dart',
+            route: '/',
+            params: [],
+          )
+        ]
+      });
+
+      reportRouteConflicts(
+        configuration,
+        onViolationStart: () {
+          violationStartCalled = true;
+        },
+        onRouteConflict: (_, __, conflictingEndpoint) {
+          conflicts.add(conflictingEndpoint);
+        },
+        onViolationEnd: () {
+          violationEndCalled = true;
+        },
+      );
+
+      expect(violationStartCalled, isFalse);
+      expect(violationEndCalled, isFalse);
+      expect(conflicts, ['/hello']);
+    });
+
+    test(
+        'reports multiple conflicts '
+        'when there are multiple endpoint with conflicts', () {
+      when(() => configuration.endpoints).thenReturn({
+        '/': const [
+          RouteFile(
+            name: 'index',
+            path: 'index.dart',
+            route: '/',
+            params: [],
+          ),
+        ],
+        '/hello': const [
+          RouteFile(
+            name: 'hello',
+            path: 'hello.dart',
+            route: '/hello',
+            params: [],
+          ),
+          RouteFile(
+            name: 'hello_index',
+            path: 'hello/index.dart',
+            route: '/',
+            params: [],
+          )
+        ],
+        '/echo': const [
+          RouteFile(
+            name: 'echo',
+            path: 'echo.dart',
+            route: '/echo',
+            params: [],
+          ),
+          RouteFile(
+            name: 'echo_index',
+            path: 'echo/index.dart',
+            route: '/',
+            params: [],
+          )
+        ]
+      });
+
+      reportRouteConflicts(
+        configuration,
+        onViolationStart: () {
+          violationStartCalled = true;
+        },
+        onRouteConflict: (_, __, conflictingEndpoint) {
+          conflicts.add(conflictingEndpoint);
+        },
+        onViolationEnd: () {
+          violationEndCalled = true;
+        },
+      );
+
+      expect(violationStartCalled, isFalse);
+      expect(violationEndCalled, isFalse);
+      expect(conflicts, ['/hello', '/echo']);
+    });
+  });
+}


### PR DESCRIPTION
## Status

**READY**

## Description

Re-land #614

Braking change: this will break the "server" bricks (see what happened to people on #626)

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
