### PR TITLE
feat: adding list command

### DIFF
--- a/packages/dart_frog_cli/.gitignore
+++ b/packages/dart_frog_cli/.gitignore
@@ -7,3 +7,5 @@ pubspec.lock
 
 # Test related files
 coverage/
+
+build

--- a/packages/dart_frog_cli/README.md
+++ b/packages/dart_frog_cli/README.md
@@ -27,7 +27,7 @@ Available commands:
   build    Create a production build.
   create   Creates a new Dart Frog app.
   dev      Run a local development server.
-  list     Lists the routes on a Dart Frog project.
+  list     Lists all the routes on a Dart Frog project.
   new      Create a new route or middleware for dart_frog.
   update   Update the Dart Frog CLI.
 

--- a/packages/dart_frog_cli/README.md
+++ b/packages/dart_frog_cli/README.md
@@ -27,6 +27,7 @@ Available commands:
   build    Create a production build.
   create   Creates a new Dart Frog app.
   dev      Run a local development server.
+  list     Lists the routes on a Dart Frog project.
   new      Create a new route or middleware for dart_frog.
   update   Update the Dart Frog CLI.
 

--- a/packages/dart_frog_cli/lib/src/command_runner.dart
+++ b/packages/dart_frog_cli/lib/src/command_runner.dart
@@ -43,6 +43,7 @@ class DartFrogCommandRunner extends CompletionCommandRunner<int> {
     addCommand(DevCommand(logger: _logger));
     addCommand(UpdateCommand(logger: _logger));
     addCommand(NewCommand(logger: _logger));
+    addCommand(ListCommand(logger: _logger));
   }
 
   final Logger _logger;

--- a/packages/dart_frog_cli/lib/src/commands/commands.dart
+++ b/packages/dart_frog_cli/lib/src/commands/commands.dart
@@ -3,6 +3,7 @@ import 'package:mason/mason.dart';
 export 'build/build.dart';
 export 'create/create.dart';
 export 'dev/dev.dart';
+export 'list/list.dart';
 export 'new/new.dart';
 
 /// A method which returns a [Future<MasonGenerator>] given a [MasonBundle].

--- a/packages/dart_frog_cli/lib/src/commands/list/list.dart
+++ b/packages/dart_frog_cli/lib/src/commands/list/list.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:dart_frog_cli/src/command.dart';
+import 'package:dart_frog_gen/dart_frog_gen.dart';
+import 'package:mason/mason.dart';
+
+/// Definition for a function that builds a [RouteConfiguration] from a
+/// [Directory].
+typedef RouteConfigurationBuilder = RouteConfiguration Function(
+  Directory directory,
+);
+
+/// {@template list_command}
+/// `dart_frog list "path/to/project"`
+///
+/// Lists the routes on the project.
+/// {@endtemplate}
+class ListCommand extends DartFrogCommand {
+  /// {@macro list_command}
+  ListCommand({
+    super.logger,
+    RouteConfigurationBuilder buildConfiguration = buildRouteConfiguration,
+  }) : _buildConfiguration = buildConfiguration;
+
+  final RouteConfigurationBuilder _buildConfiguration;
+
+  @override
+  String get description => 'Lists the routes on a Dart Frog project.';
+
+  @override
+  String get name => 'list';
+
+  @override
+  final String invocation = 'dart_frog list "path/to/project"';
+
+  @override
+  Future<int> run() async {
+    final projectDir = _projectDirectory;
+
+    final configuration = _buildConfiguration(projectDir);
+
+    logger
+      ..info('Route list 🐸:')
+      ..info('==============\n');
+
+    for (final endpoint in configuration.endpoints.keys) {
+      logger.info(endpoint);
+    }
+
+    return ExitCode.success.code;
+  }
+
+  Directory get _projectDirectory {
+    final rest = results.rest;
+    _validateProjectDirectoryArg(rest);
+    return Directory(rest.first);
+  }
+
+  void _validateProjectDirectoryArg(List<String> args) {
+    if (args.isEmpty) {
+      throw UsageException(
+        'No project directory specified.',
+        usageString,
+      );
+    }
+
+    if (args.length > 1) {
+      throw UsageException(
+        'Multiple project directories specified.',
+        usageString,
+      );
+    }
+  }
+}

--- a/packages/dart_frog_cli/lib/src/commands/list/list.dart
+++ b/packages/dart_frog_cli/lib/src/commands/list/list.dart
@@ -21,7 +21,15 @@ class ListCommand extends DartFrogCommand {
   ListCommand({
     super.logger,
     RouteConfigurationBuilder buildConfiguration = buildRouteConfiguration,
-  }) : _buildConfiguration = buildConfiguration;
+  }) : _buildConfiguration = buildConfiguration {
+    argParser.addFlag(
+      'plain',
+      abbr: 'p',
+      help: 'Return the output in a plain format, printing each route on a new '
+          'line.',
+      negatable: false,
+    );
+  }
 
   final RouteConfigurationBuilder _buildConfiguration;
 
@@ -40,9 +48,13 @@ class ListCommand extends DartFrogCommand {
 
     final configuration = _buildConfiguration(projectDir);
 
-    logger
-      ..info('Route list 🐸:')
-      ..info('==============\n');
+    final plain = results['plain'] as bool;
+
+    if (!plain) {
+      logger
+        ..info('Route list 🐸:')
+        ..info('==============\n');
+    }
 
     for (final endpoint in configuration.endpoints.keys) {
       logger.info(endpoint);
@@ -54,17 +66,12 @@ class ListCommand extends DartFrogCommand {
   Directory get _projectDirectory {
     final rest = results.rest;
     _validateProjectDirectoryArg(rest);
-    return Directory(rest.first);
+    return Directory(
+      rest.isEmpty ? Directory.current.path : rest.first,
+    );
   }
 
   void _validateProjectDirectoryArg(List<String> args) {
-    if (args.isEmpty) {
-      throw UsageException(
-        'No project directory specified.',
-        usageString,
-      );
-    }
-
     if (args.length > 1) {
       throw UsageException(
         'Multiple project directories specified.',

--- a/packages/dart_frog_cli/pubspec.yaml
+++ b/packages/dart_frog_cli/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 dependencies:
   args: ^2.1.0
   cli_completion: ^0.3.0
+  dart_frog_gen: ^0.4.0
   mason: ^0.1.0-dev.39
   meta: ^1.7.0
   path: ^1.8.1

--- a/packages/dart_frog_cli/test/src/command_runner_test.dart
+++ b/packages/dart_frog_cli/test/src/command_runner_test.dart
@@ -31,6 +31,7 @@ const expectedUsage = [
       '  build    Create a production build.\n'
       '  create   Creates a new Dart Frog app.\n'
       '  dev      Run a local development server.\n'
+      '  list     Lists the routes on a Dart Frog project.\n'
       '  new      Create a new route or middleware for dart_frog\n'
       '  update   Update the Dart Frog CLI.\n'
       '\n'

--- a/packages/dart_frog_cli/test/src/commands/list/list_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/list/list_test.dart
@@ -1,0 +1,148 @@
+// ignore_for_file: no_adjacent_strings_in_list
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
+import 'package:dart_frog_cli/src/command_runner.dart';
+import 'package:dart_frog_cli/src/commands/commands.dart';
+import 'package:dart_frog_gen/dart_frog_gen.dart';
+import 'package:mason/mason.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:pub_updater/pub_updater.dart';
+import 'package:test/test.dart';
+
+import '../../../helpers/helpers.dart';
+
+class _MockArgResults extends Mock implements ArgResults {}
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockPubUpdater extends Mock implements PubUpdater {}
+
+class _MockProcessSignal extends Mock implements ProcessSignal {}
+
+class _MockProgress extends Mock implements Progress {}
+
+class _FakeDirectoryGeneratorTarget extends Fake
+    implements DirectoryGeneratorTarget {}
+
+class _MockRouteConfiguration extends Mock implements RouteConfiguration {}
+
+const expectedUsage = [
+  'Lists the routes on a Dart Frog project.\n'
+      '\n'
+      'Usage: dart_frog list "path/to/project"\n'
+      '-h, --help    Print this usage information.\n'
+      '\n'
+      'Run "dart_frog help" to see global options.'
+];
+
+void main() {
+  group('dart_frog list', () {
+    setUpAll(() {
+      registerFallbackValue(_FakeDirectoryGeneratorTarget());
+    });
+
+    late ArgResults argResults;
+    late Logger logger;
+    late Progress progress;
+    late ListCommand command;
+    late DartFrogCommandRunner commandRunner;
+    late RouteConfiguration routeConfiguration;
+
+    setUp(() {
+      argResults = _MockArgResults();
+      logger = _MockLogger();
+      progress = _MockProgress();
+      routeConfiguration = _MockRouteConfiguration();
+      when(() => logger.progress(any())).thenReturn(progress);
+      command = ListCommand(
+        logger: logger,
+        buildConfiguration: (_) => routeConfiguration,
+      )
+        ..testArgResults = argResults
+        ..testUsage = 'test usage';
+
+      final sigint = _MockProcessSignal();
+
+      when(sigint.watch).thenAnswer((_) => const Stream.empty());
+
+      commandRunner = DartFrogCommandRunner(
+        logger: logger,
+        pubUpdater: _MockPubUpdater(),
+        exit: (_) {},
+        sigint: sigint,
+      );
+    });
+
+    test(
+      'usage shows help text',
+      overridePrint((printLogs) async {
+        final result = await commandRunner.run(['list', '--help']);
+
+        expect(result, equals(ExitCode.success.code));
+        expect(printLogs, expectedUsage);
+      }),
+    );
+
+    test('logs all the endpoints', () async {
+      when(() => routeConfiguration.endpoints).thenReturn({
+        '/turles/<id>': [],
+        '/turles/random': [],
+      });
+      final directory = Directory.systemTemp.createTempSync();
+
+      command.testCwd = directory;
+
+      when(() => argResults.rest).thenReturn(['my_project']);
+
+      await expectLater(
+        await command.run(),
+        equals(ExitCode.success.code),
+      );
+
+      verify(() => logger.info('Route list 🐸:')).called(1);
+      verify(() => logger.info('==============\n')).called(1);
+      verify(() => logger.info('/turles/<id>')).called(1);
+      verify(() => logger.info('/turles/random')).called(1);
+    });
+
+    test('fails when the project path is not specified', () async {
+      final directory = Directory.systemTemp.createTempSync();
+
+      command.testCwd = directory;
+
+      when(() => argResults.rest).thenReturn([]);
+
+      await expectLater(
+        () async => command.run(),
+        throwsA(
+          isA<UsageException>().having(
+            (p) => p.message,
+            'error message',
+            'No project directory specified.',
+          ),
+        ),
+      );
+    });
+
+    test('fails when multiple directories are specified', () async {
+      final directory = Directory.systemTemp.createTempSync();
+
+      command.testCwd = directory;
+
+      when(() => argResults.rest).thenReturn(['a', 'b']);
+
+      await expectLater(
+        () async => command.run(),
+        throwsA(
+          isA<UsageException>().having(
+            (p) => p.message,
+            'error message',
+            'Multiple project directories specified.',
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Adds a new list command to Dart frog, which will run the dart gen logic in order to gather all the endpoints available in the project, and print them in the console, making it easier for users get a summary of all the available endpoints in their project, without have to open the sourcebase in a file explorer.

This command can be improved in the future to show the HTTP method when we have a way of identifying them.

![Screenshot 2023-05-29 at 17 12 57](https://github.com/VeryGoodOpenSource/dart_frog/assets/835641/8dec4ab6-61ea-4d71-b562-5732fa286fb1)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
