### PR TITLE
feat: detect conflict between dynamic routes and non dynamic ones

### DIFF
--- a/packages/dart_frog_gen/pubspec.yaml
+++ b/packages/dart_frog_gen/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
+  equatable: ^2.0.5
   path: ^1.8.1
   pubspec_parse: ^1.2.2
 

--- a/packages/dart_frog_gen/test/src/build_route_configuration_test.dart
+++ b/packages/dart_frog_gen/test/src/build_route_configuration_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: inference_failure_on_collection_literal
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_frog_gen/src/build_route_configuration.dart';

--- a/packages/dart_frog_gen/test/src/build_route_configuration_test.dart
+++ b/packages/dart_frog_gen/test/src/build_route_configuration_test.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: inference_failure_on_collection_literal
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_frog_gen/src/build_route_configuration.dart';

--- a/packages/dart_frog_gen/test/src/validate_route_configuration/route_conflicts_test.dart
+++ b/packages/dart_frog_gen/test/src/validate_route_configuration/route_conflicts_test.dart
@@ -184,5 +184,120 @@ void main() {
       expect(violationEndCalled, isTrue);
       expect(conflicts, ['/hello', '/echo']);
     });
+
+    test(
+      'reports error when dynamic directories conflict with non dynamic files',
+      () {
+        when(() => configuration.endpoints).thenReturn({
+          '/cars/<id>': const [
+            RouteFile(
+              name: r'cars_$id_index',
+              path: '../routes/cars/[id]/index.dart',
+              route: '/',
+              params: [],
+            ),
+          ],
+          '/cars/mine': const [
+            RouteFile(
+              name: 'cars_mine',
+              path: '../routes/cars/mine.dart',
+              route: '/mine',
+              params: [],
+            ),
+          ],
+        });
+
+        reportRouteConflicts(
+          configuration,
+          onViolationStart: () {
+            violationStartCalled = true;
+          },
+          onRouteConflict: (_, __, conflictingEndpoint) {
+            conflicts.add(conflictingEndpoint);
+          },
+          onViolationEnd: () {
+            violationEndCalled = true;
+          },
+        );
+
+        expect(violationStartCalled, isTrue);
+        expect(violationEndCalled, isTrue);
+        expect(conflicts, ['/cars/<id>', '/cars/mine']);
+      },
+    );
+
+    test(
+      'reports error when dynamic directories conflict with non dynamic files, '
+      'with multiple folders',
+      () {
+        when(() => configuration.endpoints).thenReturn({
+          '/turtles/random': const [
+            RouteFile(
+              name: 'turtles_random',
+              path: '../routes/turtles/random.dart',
+              route: '/',
+              params: [],
+            ),
+          ],
+          '/turtles/<id>': const [
+            RouteFile(
+              name: r'turtles_$id_index',
+              path: '../routes/turtles/[id]/index.dart',
+              route: '/turtles/<id>',
+              params: [],
+            ),
+          ],
+          '/turtles/<id>/bla': const [
+            RouteFile(
+              name: r'turtles_$id_bla',
+              path: '../routes/turtles/[id]/bla.dart',
+              route: '/turtles/<id>/bla.dart',
+              params: [],
+            ),
+          ],
+          '/turtles/<id>/<name>': const [
+            RouteFile(
+              name: r'turtles_$id_$name_index',
+              path: '../routes/turtles/[id]/[name]/index.dart',
+              route: '/turtles/<id>/<name>/index.dart',
+              params: [],
+            ),
+          ],
+          '/turtles/<id>/<name>/ble.dart': const [
+            RouteFile(
+              name: r'turtles_$id_$name_ble.dart',
+              path: '../routes/turtles/[id]/[name]/ble.dart',
+              route: '/turtles/<id>/<name>/ble.dart',
+              params: [],
+            ),
+          ],
+        });
+
+        reportRouteConflicts(
+          configuration,
+          onViolationStart: () {
+            violationStartCalled = true;
+          },
+          onRouteConflict: (_, __, conflictingEndpoint) {
+            conflicts.add(conflictingEndpoint);
+          },
+          onViolationEnd: () {
+            violationEndCalled = true;
+          },
+        );
+
+        expect(violationStartCalled, isTrue);
+        expect(violationEndCalled, isTrue);
+        expect(
+          conflicts,
+          [
+            '/turtles/random',
+            '/turtles/<id>',
+            '/turtles/<id>/bla',
+            '/turtles/<id>/<name>',
+          ],
+        );
+      },
+    );
   });
 }

--- a/packages/dart_frog_gen/test/src/validate_route_configuration/route_conflicts_test.dart
+++ b/packages/dart_frog_gen/test/src/validate_route_configuration/route_conflicts_test.dart
@@ -1,6 +1,7 @@
 import 'package:dart_frog_gen/dart_frog_gen.dart';
 
 import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 class _MockRouteConfiguration extends Mock implements RouteConfiguration {}
@@ -240,7 +241,14 @@ void main() {
 
         expect(violationStartCalled, isTrue);
         expect(violationEndCalled, isTrue);
-        expect(conflicts, equals(['/cars/<id> and /cars/mine -> /cars/<id>']));
+        expect(
+          conflicts,
+          equals(
+            [
+              '${path.normalize('/cars/<id>')} and ${path.normalize('//cars/mine')} -> /cars/<id>',
+            ],
+          ),
+        );
       },
     );
 
@@ -322,8 +330,8 @@ void main() {
         expect(
           conflicts,
           [
-            '/turtles/<id> and /turtles/random -> /turtles/<id>',
-            '/turtles/<id>/<name> and /turtles/<id>/bla -> /turtles/<id>/<name>'
+            '${path.normalize('/turtles/<id>')} and ${path.normalize('/turtles/random')} -> /turtles/<id>',
+            '${path.normalize('/turtles/<id>/<name>')} and ${path.normalize('/turtles/<id>/bla')} -> /turtles/<id>/<name>'
           ],
         );
       },

--- a/packages/dart_frog_gen/test/src/validate_route_configuration/route_conflicts_test.dart
+++ b/packages/dart_frog_gen/test/src/validate_route_configuration/route_conflicts_test.dart
@@ -205,6 +205,7 @@ void main() {
               path: '../routes/cars/[id]/index.dart',
               route: '/',
               params: [],
+              wildcard: false,
             ),
           ],
           '/cars/mine': const [
@@ -213,6 +214,7 @@ void main() {
               path: '../routes/cars/mine.dart',
               route: '/mine',
               params: [],
+              wildcard: false,
             ),
           ],
         });
@@ -222,8 +224,14 @@ void main() {
           onViolationStart: () {
             violationStartCalled = true;
           },
-          onRouteConflict: (_, __, conflictingEndpoint) {
-            conflicts.add(conflictingEndpoint);
+          onRouteConflict: (
+            originalFilePath,
+            conflictingFilePath,
+            conflictingEndpoint,
+          ) {
+            conflicts.add('$originalFilePath and '
+                '$conflictingFilePath -> '
+                '$conflictingEndpoint');
           },
           onViolationEnd: () {
             violationEndCalled = true;
@@ -232,7 +240,7 @@ void main() {
 
         expect(violationStartCalled, isTrue);
         expect(violationEndCalled, isTrue);
-        expect(conflicts, ['/cars/<id>', '/cars/mine']);
+        expect(conflicts, equals(['/cars/<id> and /cars/mine -> /cars/<id>']));
       },
     );
 
@@ -247,6 +255,7 @@ void main() {
               path: '../routes/turtles/random.dart',
               route: '/',
               params: [],
+              wildcard: false,
             ),
           ],
           '/turtles/<id>': const [
@@ -255,6 +264,7 @@ void main() {
               path: '../routes/turtles/[id]/index.dart',
               route: '/turtles/<id>',
               params: [],
+              wildcard: false,
             ),
           ],
           '/turtles/<id>/bla': const [
@@ -263,6 +273,7 @@ void main() {
               path: '../routes/turtles/[id]/bla.dart',
               route: '/turtles/<id>/bla.dart',
               params: [],
+              wildcard: false,
             ),
           ],
           '/turtles/<id>/<name>': const [
@@ -271,6 +282,7 @@ void main() {
               path: '../routes/turtles/[id]/[name]/index.dart',
               route: '/turtles/<id>/<name>/index.dart',
               params: [],
+              wildcard: false,
             ),
           ],
           '/turtles/<id>/<name>/ble.dart': const [
@@ -279,6 +291,7 @@ void main() {
               path: '../routes/turtles/[id]/[name]/ble.dart',
               route: '/turtles/<id>/<name>/ble.dart',
               params: [],
+              wildcard: false,
             ),
           ],
         });
@@ -288,8 +301,16 @@ void main() {
           onViolationStart: () {
             violationStartCalled = true;
           },
-          onRouteConflict: (_, __, conflictingEndpoint) {
-            conflicts.add(conflictingEndpoint);
+          onRouteConflict: (
+            originalFilePath,
+            conflictingFilePath,
+            conflictingEndpoint,
+          ) {
+            conflicts.add(
+              '$originalFilePath and '
+              '$conflictingFilePath -> '
+              '$conflictingEndpoint',
+            );
           },
           onViolationEnd: () {
             violationEndCalled = true;
@@ -301,10 +322,8 @@ void main() {
         expect(
           conflicts,
           [
-            '/turtles/random',
-            '/turtles/<id>',
-            '/turtles/<id>/bla',
-            '/turtles/<id>/<name>',
+            '/turtles/<id> and /turtles/random -> /turtles/<id>',
+            '/turtles/<id>/<name> and /turtles/<id>/bla -> /turtles/<id>/<name>'
           ],
         );
       },


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

This PR adds a validation to detect dynamic routes that would eventually "override" non dynamic ones and adds an error to notify the user, so that route issue don't go unnoticeable.

Ideally, we would try to order the routes in a way that the non dynamics ones would take precedence over the dynamic, but that proved a complicated implementation which would bring many other complications related to middlewares.

Since the user can still simply use a single dynamic route to both handle a `GET /pets/123` and a `GET /pets/mine`, we decided to go with marking routes as conflicted when we encounter such cases.

Example output:
![Screenshot 2023-06-06 at 10 57 32](https://github.com/VeryGoodOpenSource/dart_frog/assets/835641/ab1a3b09-1185-4dca-94fb-9871759b7905)

Fixes #658
Fixes: #631

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
