### PR TITLE
feat: added default port number for --dart-vm-service-port

### DIFF
--- a/packages/dart_frog_cli/lib/src/commands/dev/dev.dart
+++ b/packages/dart_frog_cli/lib/src/commands/dev/dev.dart
@@ -84,9 +84,12 @@ class DevCommand extends DartFrogCommand {
       ..addOption(
         'dart-vm-service-port',
         abbr: 'd',
+        defaultsTo: _defaultDartVmServicePort,
         help: 'Which port number the dart vm service should listen on.',
       );
   }
+
+  static const _defaultDartVmServicePort = '8181';
 
   final void Function(io.Directory) _ensureRuntimeCompatibility;
   final DirectoryWatcherBuilder _directoryWatcher;
@@ -147,8 +150,8 @@ class DevCommand extends DartFrogCommand {
       logger.detail('[codegen] reload complete.');
     }
 
-    final enableVmServiceFlag = '--enable-vm-service'
-        '${dartVmServicePort == null ? "" : "=$dartVmServicePort"}';
+    final enableVmServiceFlag =
+        '--enable-vm-service=${dartVmServicePort ?? _defaultDartVmServicePort}';
 
     Future<void> serve() async {
       logger.detail(

--- a/packages/dart_frog_cli/test/src/commands/dev/dev_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/dev/dev_test.dart
@@ -587,8 +587,7 @@ void main() {
     });
 
     test(
-      'when dart vm port not specified, --enable-vm-service option should '
-      'be called without any port number value',
+      '''when dart vm port not specified, --enable-vm-service option should be called with 8181''',
       () async {
         late List<String> receivedArgs;
         command.testArgResults = argResults;
@@ -634,7 +633,7 @@ void main() {
         )..testArgResults = argResults;
         final exitCode = await command.run();
         expect(exitCode, equals(ExitCode.success.code));
-        expect(receivedArgs[0], equals('--enable-vm-service'));
+        expect(receivedArgs[0], equals('--enable-vm-service=8181'));
         verify(
           () => generatorHooks.preGen(
             vars: <String, dynamic>{'port': '8080'},


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Adds the default port number to the `--dart-vm-service-port` for:
- Better user experience (`dart_frog dev -h` now explicitly specifies the current default)
- Dart Frog will not experience a breaking change if the Dart team changes the default Dart VM service port.
Changes:
- Includes default port number information for `--dart-vm-service-port`. Set to 8181, which is the current default.

Before:
<img src=https://github.com/VeryGoodOpenSource/dart_frog/assets/44524995/935666a9-aaf8-48fe-a3b3-b50d565bca85 width="500px" img/>

After:
<img src=https://github.com/VeryGoodOpenSource/dart_frog/assets/44524995/02aee269-03a5-4f3a-b0b3-a54c9d4e617d width="500px" img/>

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
