### PR TITLE
docs: fix code blocks and styling in routes.md

### DIFF
--- a/docs/docs/basics/routes.md
+++ b/docs/docs/basics/routes.md
@@ -418,7 +418,7 @@ Response onRequest(RequestContext context, String userId, String postId) {
 
 ## Wildcard Routes ♾
 
-Dart Frog supports wildcard routes. For example, if you create a file called `routes/posts/[...page].dart`, then it will be accessible at any path that starts with `/posts/`, with any number of levels, allowing it to called from `/posts/today`, `/posts/features/stared`, and so forth.
+Dart Frog supports wildcard routes. For example, if you create a file called `routes/posts/[...page].dart`, then it will be accessible at any path that starts with `/posts/`, with any number of levels, allowing it to called from `/posts/today`, `/posts/features/starred`, and so forth.
 
 Routing parameters are forwarded to the `onRequest` method as seen below:
 
@@ -432,6 +432,7 @@ Response onRequest(RequestContext context, String page) {
 
 ```warning
 Wildcard routes **must** be unique leaf routes on their route node, meaning that they need to be a file, and they need to be the only route in their folder.
+```
 
 ## Route Conflicts 💥
 
@@ -442,13 +443,11 @@ A route conflict occurs when more than one route handler resolves to the same en
 For example, given the following file structure:
 
 ```
-
 ├── routes
 │   ├── api
 │   │   └── index.dart
 │   └── api.dart
-
-````
+```
 
 Both `routes/api/index.dart` and `routes/api.dart` resolve the the `/api` endpoint.
 
@@ -458,7 +457,7 @@ When running the development server via `dart_frog dev`, Dart Frog will report r
 [hotreload] - Application reloaded.
 
 Route conflict detected. `routes/api.dart` and `routes/api/index.dart` both resolve to `/api`.
-````
+```
 
 When generating a production build via `dart_frog build`, Dart Frog will report all detected route conflicts and fail the build if one or more route conflicts are detected.
 


### PR DESCRIPTION
Fixed the code-block/body-content formatting in the Wildcard section of the `routes.md` file.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

READY

## Description

There were some extra/missing backticks in the **Wildcard** and **Route conflicts** sections that was causing body content to be code-formatted and sample code to be body-formatted.

Also fixed a small typo in the wildcard example ("stared" --> "starred").

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
