### PR TITLE
feat(dart_frog_cli): add devserver lifecycle

### DIFF
--- a/packages/dart_frog_cli/lib/src/commands/dev/dev.dart
+++ b/packages/dart_frog_cli/lib/src/commands/dev/dev.dart
@@ -70,13 +70,22 @@ class DevCommand extends DartFrogCommand {
         _defaultDartVmServicePort;
     final generator = await _generator(dartFrogDevServerBundle);
 
-    final result = await _devServerRunnerBuilder(
+    final devServer = _devServerRunnerBuilder(
       devServerBundleGenerator: generator,
       logger: logger,
       workingDirectory: cwd,
       port: port,
       dartVmServicePort: dartVmServicePort,
-    ).start();
+    );
+
+    try {
+      await devServer.start();
+    } on DartFrogDevServerException catch (e) {
+      logger.err(e.message);
+      return ExitCode.software.code;
+    }
+
+    final result = await devServer.exitCode;
 
     return result.code;
   }

--- a/packages/dart_frog_cli/lib/src/dev_server_runner/dev_server_runner.dart
+++ b/packages/dart_frog_cli/lib/src/dev_server_runner/dev_server_runner.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
 
@@ -39,9 +40,18 @@ final _dartVmServiceAlreadyInUseErrorRegex = RegExp(
   multiLine: true,
 );
 
-// TODO(renancaraujo): Add reload and stop methods.
 /// {@template dev_server_runner}
 /// A class that manages a local development server process lifecycle.
+///
+/// The [DevServerRunner] is responsible for:
+/// - Generating the dev server runtime code.
+/// - Starting the dev server process.
+/// - Watching for file changes.
+/// - Restarting the dev server process when files change.
+/// - Stopping the dev server process when requested or under external
+/// circumstances (server process killed or watcher stopped).
+///
+/// After stopped, a [DevServerRunner] instance cannot be restarted.
 /// {@endtemplate}
 class DevServerRunner {
   /// {@macro dev_server_runner}
@@ -58,9 +68,7 @@ class DevServerRunner {
     @visibleForTesting io.ProcessSignal? sigint,
     @visibleForTesting ProcessStart? startProcess,
     @visibleForTesting ProcessRun? runProcess,
-    @visibleForTesting Exit? exit,
   })  : _directoryWatcher = directoryWatcher ?? DirectoryWatcher.new,
-        _exit = exit ?? io.exit,
         _isWindows = isWindows ?? io.Platform.isWindows,
         _sigint = sigint ?? io.ProcessSignal.sigint,
         _startProcess = startProcess ?? io.Process.start,
@@ -92,16 +100,34 @@ class DevServerRunner {
   final ProcessStart _startProcess;
   final ProcessRun _runProcess;
   final RestorableDirectoryGeneratorTargetBuilder _generatorTarget;
-  final Exit _exit;
   final bool _isWindows;
-
   final io.ProcessSignal _sigint;
-  late final _target = _generatorTarget(
-    io.Directory(path.join(workingDirectory.path, '.dart_frog')),
-    logger: logger,
+
+  late final _generatedDirectory = io.Directory(
+    path.join(workingDirectory.path, '.dart_frog'),
   );
+  late final _target = _generatorTarget(_generatedDirectory, logger: logger);
 
   var _isReloading = false;
+  io.Process? _serverProcess;
+  StreamSubscription<WatchEvent>? _watcherSubscription;
+
+  /// Whether the dev server is running.
+  bool get isServerRunning => _serverProcess != null;
+
+  /// Whether the dev server is watching for file changes.
+  bool get isWatching => _watcherSubscription != null;
+
+  /// Whether the dev server has been started and stopped.
+  bool get isCompleted => _exitCodeCompleter.isCompleted;
+
+  final Completer<ExitCode> _exitCodeCompleter = Completer<ExitCode>();
+
+  /// A [Future] that completes when the dev server stops.
+  ///
+  /// The [Future] will complete with the [ExitCode] indicating the conditions
+  /// under which the dev server ended.
+  Future<ExitCode> get exitCode => _exitCodeCompleter.future;
 
   Future<void> _codegen() async {
     logger.detail('[codegen] running pre-gen...');
@@ -129,8 +155,15 @@ class DevServerRunner {
     logger.detail('[codegen] reload complete.');
   }
 
-  Future<void> _killProcess(io.Process process) async {
+  // Internal method to kill the server process.
+  // Make sure to call `stop` after calling this method to also stop the
+  // watcher.
+  Future<void> _killServerProcess() async {
     _isReloading = false;
+    final process = _serverProcess;
+    if (process == null) {
+      return;
+    }
     logger.detail('[process] killing process...');
     if (_isWindows) {
       logger.detail('[process] taskkill /F /T /PID ${process.pid}');
@@ -139,33 +172,73 @@ class DevServerRunner {
       logger.detail('[process] process.kill()...');
       process.kill();
     }
+    _serverProcess = null;
     logger.detail('[process] killing process complete.');
   }
 
-  // TODO(renancaraujo): this method returns a future that completes when the
-  // process is killed, but it should return a future that completes when the
-  // process is finished starting.
-  /// Starts the development server.
-  Future<ExitCode> start() async {
-    var isHotReloadingEnabled = false;
+  // Internal method to cancel the watcher subscription.
+  // Make sure to call `stop` after calling this method to also stop the
+  // server process.
+  Future<void> _cancelWatcherSubscription() async {
+    if (!isWatching) {
+      return;
+    }
+    logger.detail('[watcher] cancelling subscription...');
+    await _watcherSubscription!.cancel();
+    _watcherSubscription = null;
+    logger.detail('[watcher] cancelling subscription complete.');
+  }
+
+  /// Starts the development server and a [DirectoryWatcher] subscription
+  /// that will regenerate the dev server code when files change.
+  ///
+  /// This method will throw a [DartFrogDevServerException] if called while
+  /// the dev server has been started.
+  ///
+  /// This method will throw a [DartFrogDevServerException] if called after
+  /// [stop] has been called.
+  Future<void> start() async {
+    if (isCompleted) {
+      throw DartFrogDevServerException(
+        'Cannot start a dev server after it has been stopped.',
+      );
+    }
+
+    if (isServerRunning) {
+      throw DartFrogDevServerException(
+        'Cannot start a dev server while already running.',
+      );
+    }
 
     Future<void> serve() async {
+      var isHotReloadingEnabled = false;
       final enableVmServiceFlag = '--enable-vm-service=$dartVmServicePort';
 
-      logger.detail(
-        '''[process] dart $enableVmServiceFlag ${path.join('.dart_frog', 'server.dart')}''',
+      final serverDartFilePath = path.join(
+        _generatedDirectory.absolute.path,
+        'server.dart',
       );
 
-      final process = await _startProcess(
+      logger.detail(
+        '''[process] dart $enableVmServiceFlag $serverDartFilePath''',
+      );
+
+      final process = _serverProcess = await _startProcess(
         'dart',
-        [enableVmServiceFlag, path.join('.dart_frog', 'server.dart')],
+        [enableVmServiceFlag, serverDartFilePath],
         runInShell: true,
       );
 
       // On Windows listen for CTRL-C and use taskkill to kill
       // the spawned process along with any child processes.
       // https://github.com/dart-lang/sdk/issues/22470
-      if (_isWindows) _sigint.watch().listen((_) => _killProcess(process));
+      if (_isWindows) {
+        _sigint.watch().listen((_) {
+          // Do not await on sigint
+          _killServerProcess().ignore();
+          stop();
+        });
+      }
 
       var hasError = false;
       process.stderr.listen((_) async {
@@ -194,9 +267,11 @@ class DevServerRunner {
 
         if ((!isHotReloadingEnabled && !isSDKWarning) ||
             isDartVMServiceAlreadyInUseError) {
-          await _killProcess(process);
-          logger.detail('[process] exit(1)');
-          _exit(1);
+          await _killServerProcess();
+          const exitCode = ExitCode.software;
+          logger.detail('[process] exit(${exitCode.code})');
+          await stop(exitCode);
+          return;
         }
 
         await _target.rollback();
@@ -211,6 +286,15 @@ class DevServerRunner {
         if (shouldCacheSnapshot) _target.cacheLatestSnapshot();
         hasError = false;
       });
+
+      process.exitCode.then((code) async {
+        if (isCompleted) return;
+        logger
+          ..info('[process] Server process has been terminated')
+          ..detail('[process] exit($code)');
+        await _killServerProcess();
+        await stop(ExitCode.unavailable);
+      }).ignore();
     }
 
     final progress = logger.progress('Serving');
@@ -235,13 +319,59 @@ class DevServerRunner {
     }
 
     final watcher = _directoryWatcher(path.join(cwdPath));
-    final subscription = watcher.events
+    _watcherSubscription = watcher.events
         .where(shouldReload)
         .debounce(Duration.zero)
         .listen((_) => _reload());
 
-    await subscription.asFuture<void>();
-    await subscription.cancel();
-    return ExitCode.success;
+    _watcherSubscription!.asFuture<void>().then((_) async {
+      await _cancelWatcherSubscription();
+      await stop();
+    }).catchError((_) async {
+      await _cancelWatcherSubscription();
+      await stop(ExitCode.software);
+    }).ignore();
   }
+
+  /// Stops the development server and the watcher then
+  /// completes [DevServerRunner.exitCode] with the given [exitCode].
+  ///
+  /// If [exitCode] is not provided, it defaults to [ExitCode.success].
+  ///
+  /// After calling [stop], the dev server cannot be restarted.
+  ///
+  /// This can be called internally if the server process is killed or if the
+  /// watcher stops watching.
+  Future<void> stop([ExitCode exitCode = ExitCode.success]) async {
+    if (isCompleted) {
+      return;
+    }
+
+    if (isWatching) {
+      await _cancelWatcherSubscription();
+    }
+    if (isServerRunning) {
+      await _killServerProcess();
+    }
+
+    _exitCodeCompleter.complete(exitCode);
+  }
+
+  /// Regenerates the dev server code and sends a hot reload signal to the
+  /// server.
+  Future<void> reload() async {
+    if (isCompleted || !isServerRunning || _isReloading) return;
+    return _reload();
+  }
+}
+
+/// {@template dart_frog_dev_server_exception}
+/// Exception thrown when the dev server fails to start.
+/// {@endtemplate}
+class DartFrogDevServerException implements Exception {
+  /// {@macro dart_frog_dev_server_exception}
+  DartFrogDevServerException(this.message);
+
+  /// The exception message.
+  final String message;
 }

--- a/packages/dart_frog_cli/lib/src/runtime_compatibility.dart
+++ b/packages/dart_frog_cli/lib/src/runtime_compatibility.dart
@@ -15,7 +15,7 @@ class DartFrogCompatibilityException implements Exception {
   /// {@macro dart_frog_compatibility_exception}
   const DartFrogCompatibilityException(this.message);
 
-  /// The error message.
+  /// The exception message.
   final String message;
 
   @override

--- a/packages/dart_frog_cli/test/src/commands/dev_server_runner/dev_server_runner_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/dev_server_runner/dev_server_runner_test.dart
@@ -705,7 +705,7 @@ runs codegen with debounce when changes are made to the public or routes directo
           await Future<void>.delayed(Duration.zero);
 
           verify(
-            () => logger.info('[process] server process has been terminated'),
+            () => logger.info('[process] Server process has been terminated'),
           ).called(1);
           verify(() => process.kill()).called(1);
           await expectLater(

--- a/packages/dart_frog_cli/test/src/commands/dev_server_runner/dev_server_runner_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/dev_server_runner/dev_server_runner_test.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' hide exitCode;
 
 import 'package:dart_frog_cli/src/dev_server_runner/dev_server_runner.dart';
 import 'package:dart_frog_cli/src/dev_server_runner/restorable_directory_generator_target.dart';
@@ -49,6 +49,7 @@ void main() {
   late Process process;
   late ProcessSignal sigint;
   late RestorableDirectoryGeneratorTarget generatorTarget;
+  late GeneratorHooks generatorHooks;
 
   late DevServerRunner devServerRunner;
 
@@ -64,31 +65,51 @@ void main() {
 
     when(() => logger.progress(any())).thenReturn(progress);
 
+    when(() => directoryWatcher.events).thenAnswer((_) => const Stream.empty());
+    when(process.kill).thenAnswer((invocation) => true);
+    final completer = Completer<int>();
+    when(() => process.exitCode).thenAnswer((_) => completer.future);
+
     devServerRunner = DevServerRunner(
       logger: logger,
       port: port,
       devServerBundleGenerator: generator,
       dartVmServicePort: dartVmServicePort,
       workingDirectory: Directory.current,
-      // test
       directoryWatcher: (_) => directoryWatcher,
-      generatorTarget: (
-        _, {
-        CreateFile? createFile,
-        Logger? logger,
-      }) =>
-          generatorTarget,
+      generatorTarget: (_, {createFile, logger}) => generatorTarget,
       isWindows: isWindows,
-      startProcess: (
-        String executable,
-        List<String> arguments, {
-        bool runInShell = false,
-      }) async {
-        return process;
-      },
+      startProcess: (_, __, {runInShell = false}) async => process,
       sigint: sigint,
       runProcess: (_, __) async => processResult,
     );
+
+    when(() => process.stdout).thenAnswer((_) => const Stream.empty());
+    when(() => process.stderr).thenAnswer((_) => const Stream.empty());
+
+    generatorHooks = _MockGeneratorHooks();
+
+    when(
+      () => generatorHooks.preGen(
+        vars: any(named: 'vars'),
+        workingDirectory: any(named: 'workingDirectory'),
+        onVarsChanged: any(named: 'onVarsChanged'),
+      ),
+    ).thenAnswer((invocation) async {
+      (invocation.namedArguments[const Symbol('onVarsChanged')] as void
+              Function(Map<String, dynamic> vars))
+          .call(<String, dynamic>{});
+    });
+
+    when(
+      () => generator.generate(
+        any(),
+        vars: any(named: 'vars'),
+        fileConflictResolution: FileConflictResolution.overwrite,
+      ),
+    ).thenAnswer((_) async => []);
+    when(() => generator.hooks).thenReturn(generatorHooks);
+    when(() => process.pid).thenReturn(processId);
   });
 
   group('$DevServerRunner', () {
@@ -104,833 +125,757 @@ void main() {
         isNotNull,
       );
     });
-  });
 
-  test('runs a dev server successfully.', () async {
-    final generatorHooks = _MockGeneratorHooks();
-    when(
-      () => generatorHooks.preGen(
-        vars: any(named: 'vars'),
-        workingDirectory: any(named: 'workingDirectory'),
-        onVarsChanged: any(named: 'onVarsChanged'),
-      ),
-    ).thenAnswer((invocation) async {
-      (invocation.namedArguments[const Symbol('onVarsChanged')] as void
-              Function(Map<String, dynamic> vars))
-          .call(<String, dynamic>{});
-    });
-    when(
-      () => generator.generate(
-        any(),
-        vars: any(named: 'vars'),
-        fileConflictResolution: FileConflictResolution.overwrite,
-      ),
-    ).thenAnswer((_) async => []);
-    when(() => generator.hooks).thenReturn(generatorHooks);
-    when(() => process.stdout).thenAnswer((_) => const Stream.empty());
-    when(() => process.stderr).thenAnswer((_) => const Stream.empty());
-    when(
-      () => directoryWatcher.events,
-    ).thenAnswer(
-      (_) => Stream.value(WatchEvent(ChangeType.MODIFY, 'README.md')),
-    );
+    group('start', () {
+      test('starts a dev server successfully.', () async {
+        when(
+          () => directoryWatcher.events,
+        ).thenAnswer(
+          (_) => Stream.value(WatchEvent(ChangeType.MODIFY, 'README.md')),
+        );
 
-    final exitCode = await devServerRunner.start();
-    expect(exitCode, equals(ExitCode.success));
-    verify(
-      () => generatorHooks.preGen(
-        vars: <String, dynamic>{'port': '8080'},
-        workingDirectory: any(named: 'workingDirectory'),
-        onVarsChanged: any(named: 'onVarsChanged'),
-      ),
-    ).called(1);
-  });
+        await expectLater(devServerRunner.start(), completes);
 
-  test('logs process.stdout', () async {
-    final generatorHooks = _MockGeneratorHooks();
-    when(
-      () => generatorHooks.preGen(
-        vars: any(named: 'vars'),
-        workingDirectory: any(named: 'workingDirectory'),
-        onVarsChanged: any(named: 'onVarsChanged'),
-      ),
-    ).thenAnswer((invocation) async {
-      (invocation.namedArguments[const Symbol('onVarsChanged')] as void
-              Function(Map<String, dynamic> vars))
-          .call(<String, dynamic>{});
-    });
-    when(
-      () => generator.generate(
-        any(),
-        vars: any(named: 'vars'),
-        fileConflictResolution: FileConflictResolution.overwrite,
-      ),
-    ).thenAnswer((_) async => []);
-    when(() => generator.hooks).thenReturn(generatorHooks);
-    when(() => process.stdout).thenAnswer(
-      (_) => Stream.fromIterable([
-        utf8.encode('  Message A  '),
-        utf8.encode(''),
-        utf8.encode(' Message B'),
-        utf8.encode(' '),
-        utf8.encode('Message C '),
-        utf8.encode('  '),
-        utf8.encode('Message D'),
-      ]),
-    );
-    when(() => process.stderr).thenAnswer((_) => const Stream.empty());
-    when(
-      () => directoryWatcher.events,
-    ).thenAnswer((_) => const Stream.empty());
-
-    devServerRunner.start().ignore();
-
-    await Future<void>.delayed(Duration.zero);
-
-    verifyInOrder([
-      () => logger.info('Message A'),
-      () => logger.info('Message B'),
-      () => logger.info('Message C'),
-      () => logger.info('Message D'),
-    ]);
-  });
-
-  test(
-    'runs codegen w/debounce '
-    'when changes are made to the public/routes directory',
-    () async {
-      final controller = StreamController<WatchEvent>();
-      final generatorHooks = _MockGeneratorHooks();
-      when(
-        () => generatorHooks.preGen(
-          vars: any(named: 'vars'),
-          workingDirectory: any(named: 'workingDirectory'),
-          onVarsChanged: any(named: 'onVarsChanged'),
-        ),
-      ).thenAnswer((invocation) async {
-        (invocation.namedArguments[const Symbol('onVarsChanged')] as void
-                Function(Map<String, dynamic> vars))
-            .call(<String, dynamic>{});
-      });
-      when(
-        () => generator.generate(
-          any(),
-          vars: any(named: 'vars'),
-          fileConflictResolution: FileConflictResolution.overwrite,
-        ),
-      ).thenAnswer((_) async => []);
-      when(() => generator.hooks).thenReturn(generatorHooks);
-      when(() => process.stdout).thenAnswer(
-        (_) => Stream.value(utf8.encode('[hotreload] hot reload enabled.')),
-      );
-      when(() => process.stderr).thenAnswer((_) => const Stream.empty());
-      when(() => directoryWatcher.events).thenAnswer((_) => controller.stream);
-
-      devServerRunner.start().ignore();
-
-      await Future<void>.delayed(Duration.zero);
-
-      verify(
-        () => generator.generate(
-          any(),
-          vars: any(named: 'vars'),
-          fileConflictResolution: FileConflictResolution.overwrite,
-        ),
-      ).called(1);
-
-      controller
-        ..add(
-          WatchEvent(
-            ChangeType.ADD,
-            path.join(Directory.current.path, 'routes', 'users.dart'),
+        expect(devServerRunner.isWatching, isTrue);
+        expect(devServerRunner.isServerRunning, isTrue);
+        expect(devServerRunner.isCompleted, isFalse);
+        verify(
+          () => generatorHooks.preGen(
+            vars: <String, dynamic>{'port': '8080'},
+            workingDirectory: any(named: 'workingDirectory'),
+            onVarsChanged: any(named: 'onVarsChanged'),
           ),
-        )
-        ..add(
-          WatchEvent(
-            ChangeType.REMOVE,
-            path.join(Directory.current.path, 'routes', 'user.dart'),
+        ).called(1);
+      });
+
+      test('throws when server process is already running', () async {
+        await expectLater(devServerRunner.start(), completes);
+
+        await expectLater(
+          devServerRunner.start(),
+          throwsA(
+            isA<DartFrogDevServerException>().having(
+              (e) => e.message,
+              'message',
+              'Cannot start a dev server while already running.',
+            ),
+          ),
+        );
+      });
+
+      test('throws when dev server has been completed', () async {
+        await expectLater(devServerRunner.start(), completes);
+
+        await devServerRunner.exitCode;
+
+        await expectLater(
+          devServerRunner.start(),
+          throwsA(
+            isA<DartFrogDevServerException>().having(
+              (e) => e.message,
+              'message',
+              'Cannot start a dev server after it has been stopped.',
+            ),
+          ),
+        );
+      });
+
+      test('custom port numbers', () async {
+        late List<String> receivedArgs;
+
+        devServerRunner = DevServerRunner(
+          logger: logger,
+          port: '4242',
+          devServerBundleGenerator: generator,
+          dartVmServicePort: '4343',
+          workingDirectory: Directory.current,
+          directoryWatcher: (_) => directoryWatcher,
+          generatorTarget: (_, {createFile, logger}) => generatorTarget,
+          isWindows: isWindows,
+          startProcess: (
+            String executable,
+            List<String> arguments, {
+            bool runInShell = false,
+          }) async {
+            receivedArgs = arguments;
+            return process;
+          },
+          sigint: sigint,
+          runProcess: (_, __) async => processResult,
+        );
+
+        await expectLater(devServerRunner.start(), completes);
+
+        expect(devServerRunner.isWatching, isTrue);
+        expect(devServerRunner.isServerRunning, isTrue);
+        expect(devServerRunner.isCompleted, isFalse);
+
+        expect(
+          receivedArgs,
+          equals([
+            '--enable-vm-service=4343',
+            endsWith('.dart_frog/server.dart'),
+          ]),
+        );
+        verify(
+          () => generatorHooks.preGen(
+            vars: <String, dynamic>{'port': '4242'},
+            workingDirectory: any(named: 'workingDirectory'),
+            onVarsChanged: any(named: 'onVarsChanged'),
+          ),
+        ).called(1);
+      });
+
+      test(
+        'kills process if error occurs before hot reload is enabled on windows',
+        () async {
+          final processRunCalls = <List<String>>[];
+          when(() => process.stderr).thenAnswer(
+            (_) => Stream.value(utf8.encode('oops')),
+          );
+
+          when(
+            () => directoryWatcher.events,
+          ).thenAnswer((_) => StreamController<WatchEvent>().stream);
+          when(() => sigint.watch()).thenAnswer((_) => const Stream.empty());
+          devServerRunner = DevServerRunner(
+            logger: logger,
+            port: port,
+            devServerBundleGenerator: generator,
+            dartVmServicePort: dartVmServicePort,
+            workingDirectory: Directory.current,
+            directoryWatcher: (_) => directoryWatcher,
+            isWindows: true,
+            startProcess: (_, __, {runInShell = false}) async => process,
+            sigint: sigint,
+            runProcess: (String executable, List<String> arguments) async {
+              processRunCalls.add([executable, ...arguments]);
+              return processResult;
+            },
+          );
+          await expectLater(devServerRunner.start(), completes);
+
+          final exitCode = await devServerRunner.exitCode;
+
+          expect(devServerRunner.isWatching, isFalse);
+          expect(devServerRunner.isServerRunning, isFalse);
+          expect(devServerRunner.isCompleted, isTrue);
+          expect(exitCode.code, 70);
+          expect(
+            processRunCalls,
+            equals([
+              ['taskkill', '/F', '/T', '/PID', '$processId']
+            ]),
+          );
+          verifyNever(() => process.kill());
+        },
+      );
+
+      test('logs process.stdout', () async {
+        when(() => process.stdout).thenAnswer(
+          (_) => Stream.fromIterable([
+            utf8.encode('  Message A  '),
+            utf8.encode(''),
+            utf8.encode(' Message B'),
+            utf8.encode(' '),
+            utf8.encode('Message C '),
+            utf8.encode('  '),
+            utf8.encode('Message D'),
+          ]),
+        );
+        when(
+          () => directoryWatcher.events,
+        ).thenAnswer((_) => const Stream.empty());
+
+        await expectLater(devServerRunner.start(), completes);
+
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        verifyInOrder([
+          () => logger.info('Message A'),
+          () => logger.info('Message B'),
+          () => logger.info('Message C'),
+          () => logger.info('Message D'),
+        ]);
+      });
+    });
+
+    group('reload and codegen', () {
+      test('reloads successfully when .reload is called', () async {
+        await expectLater(devServerRunner.start(), completes);
+
+        verify(
+          () => generator.generate(
+            any(),
+            vars: any(named: 'vars'),
+            fileConflictResolution: FileConflictResolution.overwrite,
+          ),
+        ).called(1);
+
+        await devServerRunner.reload();
+
+        verify(
+          () => generator.generate(
+            any(),
+            vars: any(named: 'vars'),
+            fileConflictResolution: FileConflictResolution.overwrite,
+          ),
+        ).called(1);
+      });
+
+      test('does not reload when dev server is completed', () async {
+        await expectLater(devServerRunner.start(), completes);
+
+        verify(
+          () => generator.generate(
+            any(),
+            vars: any(named: 'vars'),
+            fileConflictResolution: FileConflictResolution.overwrite,
+          ),
+        ).called(1);
+
+        await expectLater(devServerRunner.stop(), completes);
+
+        await devServerRunner.reload();
+
+        verifyNever(
+          () => generator.generate(
+            any(),
+            vars: any(named: 'vars'),
+            fileConflictResolution: FileConflictResolution.overwrite,
+          ),
+        );
+      });
+
+      test('does not reload when dev server is not running ', () async {
+        await devServerRunner.reload();
+
+        verifyNever(
+          () => generator.generate(
+            any(),
+            vars: any(named: 'vars'),
+            fileConflictResolution: FileConflictResolution.overwrite,
+          ),
+        );
+      });
+
+      test('does not reload when reloading ', () async {
+        await expectLater(devServerRunner.start(), completes);
+
+        verify(
+          () => generator.generate(
+            any(),
+            vars: any(named: 'vars'),
+            fileConflictResolution: FileConflictResolution.overwrite,
+          ),
+        ).called(1);
+
+        final reloadFuture = devServerRunner.reload();
+
+        devServerRunner.reload().ignore();
+
+        verifyNever(
+          () => generator.generate(
+            any(),
+            vars: any(named: 'vars'),
+            fileConflictResolution: FileConflictResolution.overwrite,
           ),
         );
 
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+        await reloadFuture;
 
-      verify(
-        () => generator.generate(
-          any(),
-          vars: any(named: 'vars'),
-          fileConflictResolution: FileConflictResolution.overwrite,
-        ),
-      ).called(1);
-
-      controller.add(
-        WatchEvent(
-          ChangeType.MODIFY,
-          path.join(Directory.current.path, 'public', 'hello.txt'),
-        ),
-      );
-
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
-
-      verify(
-        () => generator.generate(
-          any(),
-          vars: any(named: 'vars'),
-          fileConflictResolution: FileConflictResolution.overwrite,
-        ),
-      ).called(1);
-
-      controller.add(
-        WatchEvent(
-          ChangeType.MODIFY,
-          path.join(Directory.current.path, 'tmp', 'message.txt'),
-        ),
-      );
-
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
-
-      verifyNever(
-        () => generator.generate(
-          any(),
-          vars: any(named: 'vars'),
-          fileConflictResolution: FileConflictResolution.overwrite,
-        ),
-      );
-    },
-  );
-
-  test('runs codegen when changes are made to main.dart', () async {
-    final controller = StreamController<WatchEvent>();
-    final generatorHooks = _MockGeneratorHooks();
-    when(
-      () => generatorHooks.preGen(
-        vars: any(named: 'vars'),
-        workingDirectory: any(named: 'workingDirectory'),
-        onVarsChanged: any(named: 'onVarsChanged'),
-      ),
-    ).thenAnswer((invocation) async {
-      (invocation.namedArguments[const Symbol('onVarsChanged')] as void
-              Function(Map<String, dynamic> vars))
-          .call(<String, dynamic>{});
-    });
-    when(
-      () => generator.generate(
-        any(),
-        vars: any(named: 'vars'),
-        fileConflictResolution: FileConflictResolution.overwrite,
-      ),
-    ).thenAnswer((_) async => []);
-    when(() => generator.hooks).thenReturn(generatorHooks);
-    when(() => process.stdout).thenAnswer(
-      (_) => Stream.value(utf8.encode('[hotreload] hot reload enabled.')),
-    );
-    when(() => process.stderr).thenAnswer((_) => const Stream.empty());
-    when(() => directoryWatcher.events).thenAnswer((_) => controller.stream);
-
-    devServerRunner.start().ignore();
-
-    await Future<void>.delayed(Duration.zero);
-
-    verify(
-      () => generator.generate(
-        any(),
-        vars: any(named: 'vars'),
-        fileConflictResolution: FileConflictResolution.overwrite,
-      ),
-    ).called(1);
-
-    controller.add(
-      WatchEvent(
-        ChangeType.ADD,
-        path.join(Directory.current.path, 'main.dart'),
-      ),
-    );
-
-    await Future<void>.delayed(Duration.zero);
-    await Future<void>.delayed(Duration.zero);
-
-    verify(
-      () => generator.generate(
-        any(),
-        vars: any(named: 'vars'),
-        fileConflictResolution: FileConflictResolution.overwrite,
-      ),
-    ).called(1);
-  });
-
-  test('runs codegen when changes are made to pubspec.yaml', () async {
-    final controller = StreamController<WatchEvent>();
-    final generatorHooks = _MockGeneratorHooks();
-    when(
-      () => generatorHooks.preGen(
-        vars: any(named: 'vars'),
-        workingDirectory: any(named: 'workingDirectory'),
-        onVarsChanged: any(named: 'onVarsChanged'),
-      ),
-    ).thenAnswer((invocation) async {
-      (invocation.namedArguments[const Symbol('onVarsChanged')] as void
-              Function(Map<String, dynamic> vars))
-          .call(<String, dynamic>{});
-    });
-    when(
-      () => generator.generate(
-        any(),
-        vars: any(named: 'vars'),
-        fileConflictResolution: FileConflictResolution.overwrite,
-      ),
-    ).thenAnswer((_) async => []);
-    when(() => generator.hooks).thenReturn(generatorHooks);
-    when(() => process.stdout).thenAnswer(
-      (_) => Stream.value(utf8.encode('[hotreload] hot reload enabled.')),
-    );
-    when(() => process.stderr).thenAnswer((_) => const Stream.empty());
-    when(() => directoryWatcher.events).thenAnswer((_) => controller.stream);
-
-    devServerRunner.start().ignore();
-
-    await Future<void>.delayed(Duration.zero);
-
-    verify(
-      () => generator.generate(
-        any(),
-        vars: any(named: 'vars'),
-        fileConflictResolution: FileConflictResolution.overwrite,
-      ),
-    ).called(1);
-
-    controller.add(
-      WatchEvent(
-        ChangeType.MODIFY,
-        path.join(Directory.current.path, 'pubspec.yaml'),
-      ),
-    );
-
-    await Future<void>.delayed(Duration.zero);
-    await Future<void>.delayed(Duration.zero);
-
-    verify(
-      () => generator.generate(
-        any(),
-        vars: any(named: 'vars'),
-        fileConflictResolution: FileConflictResolution.overwrite,
-      ),
-    ).called(1);
-  });
-
-  test('caches snapshot when hotreload runs successfully', () async {
-    final generatorHooks = _MockGeneratorHooks();
-    when(
-      () => generatorHooks.preGen(
-        vars: any(named: 'vars'),
-        workingDirectory: any(named: 'workingDirectory'),
-        onVarsChanged: any(named: 'onVarsChanged'),
-      ),
-    ).thenAnswer((invocation) async {
-      (invocation.namedArguments[const Symbol('onVarsChanged')] as void
-              Function(Map<String, dynamic> vars))
-          .call(<String, dynamic>{});
-    });
-    when(
-      () => generator.generate(
-        any(),
-        vars: any(named: 'vars'),
-        fileConflictResolution: FileConflictResolution.overwrite,
-      ),
-    ).thenAnswer((_) async => []);
-    when(() => generator.hooks).thenReturn(generatorHooks);
-    when(() => process.stdout).thenAnswer(
-      (_) => Stream.value(utf8.encode('[hotreload] hot reload enabled.')),
-    );
-    when(() => process.stderr).thenAnswer((_) => const Stream.empty());
-    when(() => directoryWatcher.events).thenAnswer(
-      (_) => const Stream.empty(),
-    );
-    final exitCode = await devServerRunner.start();
-    expect(exitCode, equals(ExitCode.success));
-    verify(() => generatorTarget.cacheLatestSnapshot()).called(1);
-  });
-
-  test('restores previous snapshot when hotreload fails.', () async {
-    final generatorHooks = _MockGeneratorHooks();
-    final stdoutController = StreamController<List<int>>();
-    final stderrController = StreamController<List<int>>();
-    when(
-      () => generatorHooks.preGen(
-        vars: any(named: 'vars'),
-        workingDirectory: any(named: 'workingDirectory'),
-        onVarsChanged: any(named: 'onVarsChanged'),
-      ),
-    ).thenAnswer((invocation) async {
-      (invocation.namedArguments[const Symbol('onVarsChanged')] as void
-              Function(Map<String, dynamic> vars))
-          .call(<String, dynamic>{});
-    });
-    when(
-      () => generator.generate(
-        any(),
-        vars: any(named: 'vars'),
-        fileConflictResolution: FileConflictResolution.overwrite,
-      ),
-    ).thenAnswer((_) async => []);
-    when(() => generator.hooks).thenReturn(generatorHooks);
-    when(() => generatorTarget.rollback()).thenAnswer((_) async {});
-    when(() => process.stdout).thenAnswer((_) => stdoutController.stream);
-    when(() => process.stderr).thenAnswer((_) => stderrController.stream);
-    when(() => directoryWatcher.events).thenAnswer(
-      (_) => const Stream.empty(),
-    );
-
-    devServerRunner.start().ignore();
-
-    stdoutController.add(utf8.encode('[hotreload] hot reload enabled'));
-    await untilCalled(() => generatorTarget.cacheLatestSnapshot());
-
-    const error = 'something went wrong';
-
-    stderrController.add(utf8.encode(error));
-    await untilCalled(() => generatorTarget.rollback());
-
-    await stderrController.close();
-    await stdoutController.close();
-
-    verify(() => generatorTarget.cacheLatestSnapshot()).called(1);
-    verify(() => generatorTarget.rollback()).called(1);
-    verify(() => logger.err(error)).called(1);
-  });
-
-  test('custom port numbers', () async {
-    final generatorHooks = _MockGeneratorHooks();
-    when(
-      () => generatorHooks.preGen(
-        vars: any(named: 'vars'),
-        workingDirectory: any(named: 'workingDirectory'),
-        onVarsChanged: any(named: 'onVarsChanged'),
-      ),
-    ).thenAnswer((invocation) async {
-      (invocation.namedArguments[const Symbol('onVarsChanged')] as void
-              Function(Map<String, dynamic> vars))
-          .call(<String, dynamic>{});
-    });
-    when(
-      () => generator.generate(
-        any(),
-        vars: any(named: 'vars'),
-        fileConflictResolution: FileConflictResolution.overwrite,
-      ),
-    ).thenAnswer((_) async => []);
-    when(() => generator.hooks).thenReturn(generatorHooks);
-    when(() => process.stdout).thenAnswer((_) => const Stream.empty());
-    when(() => process.stderr).thenAnswer((_) => const Stream.empty());
-    when(() => directoryWatcher.events).thenAnswer((_) => const Stream.empty());
-
-    late List<String> receivedArgs;
-
-    devServerRunner = DevServerRunner(
-      logger: logger,
-      port: '4242',
-      devServerBundleGenerator: generator,
-      dartVmServicePort: '4343',
-      workingDirectory: Directory.current,
-      // test
-
-      directoryWatcher: (_) => directoryWatcher,
-      generatorTarget: (
-        _, {
-        CreateFile? createFile,
-        Logger? logger,
-      }) =>
-          generatorTarget,
-      isWindows: isWindows,
-      startProcess: (
-        String executable,
-        List<String> arguments, {
-        bool runInShell = false,
-      }) async {
-        receivedArgs = arguments;
-        return process;
-      },
-      sigint: sigint,
-      runProcess: (_, __) async => processResult,
-    );
-
-    final exitCode = await devServerRunner.start();
-    expect(exitCode, equals(ExitCode.success));
-
-    expect(
-      receivedArgs,
-      equals([
-        '--enable-vm-service=4343',
-        '.dart_frog/server.dart',
-      ]),
-    );
-    verify(
-      () => generatorHooks.preGen(
-        vars: <String, dynamic>{'port': '4242'},
-        workingDirectory: any(named: 'workingDirectory'),
-        onVarsChanged: any(named: 'onVarsChanged'),
-      ),
-    ).called(1);
-  });
-
-  test('kills all child processes when sigint received on windows', () async {
-    final generatorHooks = _MockGeneratorHooks();
-    final processRunCalls = <List<String>>[];
-
-    when(
-      () => generatorHooks.preGen(
-        vars: any(named: 'vars'),
-        workingDirectory: any(named: 'workingDirectory'),
-        onVarsChanged: any(named: 'onVarsChanged'),
-      ),
-    ).thenAnswer((invocation) async {
-      (invocation.namedArguments[const Symbol('onVarsChanged')] as void
-              Function(Map<String, dynamic> vars))
-          .call(<String, dynamic>{});
-    });
-    when(
-      () => generator.generate(
-        any(),
-        vars: any(named: 'vars'),
-        fileConflictResolution: FileConflictResolution.overwrite,
-      ),
-    ).thenAnswer((_) async => []);
-    when(() => generator.hooks).thenReturn(generatorHooks);
-    when(() => process.stdout).thenAnswer((_) => const Stream.empty());
-    when(() => process.stderr).thenAnswer((_) => const Stream.empty());
-    when(() => process.pid).thenReturn(processId);
-    when(
-      () => directoryWatcher.events,
-    ).thenAnswer((_) => StreamController<WatchEvent>().stream);
-    when(() => sigint.watch()).thenAnswer((_) => Stream.value(sigint));
-    devServerRunner = DevServerRunner(
-      logger: logger,
-      port: port,
-      devServerBundleGenerator: generator,
-      dartVmServicePort: dartVmServicePort,
-      workingDirectory: Directory.current,
-      // test
-
-      directoryWatcher: (_) => directoryWatcher,
-      exit: (code) => exitCode = code,
-      isWindows: true,
-      startProcess: (
-        String executable,
-        List<String> arguments, {
-        bool runInShell = false,
-      }) async {
-        return process;
-      },
-      sigint: sigint,
-      runProcess: (String executable, List<String> arguments) async {
-        processRunCalls.add([executable, ...arguments]);
-        return processResult;
-      },
-    );
-
-    devServerRunner.start().ignore();
-    await untilCalled(() => process.pid);
-    expect(
-      processRunCalls,
-      equals([
-        ['taskkill', '/F', '/T', '/PID', '$processId']
-      ]),
-    );
-    verifyNever(() => process.kill());
-  });
-
-  test(
-    'kills process if error occurs before hotreload is enabled on windows',
-    () async {
-      final generatorHooks = _MockGeneratorHooks();
-      final processRunCalls = <List<String>>[];
-      int? exitCode;
-      when(
-        () => generatorHooks.preGen(
-          vars: any(named: 'vars'),
-          workingDirectory: any(named: 'workingDirectory'),
-          onVarsChanged: any(named: 'onVarsChanged'),
-        ),
-      ).thenAnswer((invocation) async {
-        (invocation.namedArguments[const Symbol('onVarsChanged')] as void
-                Function(Map<String, dynamic> vars))
-            .call(<String, dynamic>{});
+        verify(
+          () => generator.generate(
+            any(),
+            vars: any(named: 'vars'),
+            fileConflictResolution: FileConflictResolution.overwrite,
+          ),
+        ).called(1);
       });
-      when(
-        () => generator.generate(
-          any(),
-          vars: any(named: 'vars'),
-          fileConflictResolution: FileConflictResolution.overwrite,
-        ),
-      ).thenAnswer((_) async => []);
-      when(() => generator.hooks).thenReturn(generatorHooks);
-      when(() => process.stdout).thenAnswer((_) => const Stream.empty());
-      when(() => process.stderr).thenAnswer(
-        (_) => Stream.value(utf8.encode('oops')),
-      );
-      when(() => process.pid).thenReturn(processId);
-      when(
-        () => directoryWatcher.events,
-      ).thenAnswer((_) => StreamController<WatchEvent>().stream);
-      when(() => sigint.watch()).thenAnswer((_) => const Stream.empty());
-      devServerRunner = DevServerRunner(
-        logger: logger,
-        port: port,
-        devServerBundleGenerator: generator,
-        dartVmServicePort: dartVmServicePort,
-        workingDirectory: Directory.current,
-        // test
 
-        directoryWatcher: (_) => directoryWatcher,
-        exit: (code) => exitCode = code,
-        isWindows: true,
-        startProcess: (
-          String executable,
-          List<String> arguments, {
-          bool runInShell = false,
-        }) async {
-          return process;
+      test('completes dev server when watcher ends', () async {
+        final controller = StreamController<WatchEvent>();
+        when(() => process.stdout).thenAnswer(
+          (_) => Stream.value(utf8.encode('[hotreload] hot reload enabled.')),
+        );
+        when(() => directoryWatcher.events)
+            .thenAnswer((_) => controller.stream);
+        await expectLater(devServerRunner.start(), completes);
+
+        expect(devServerRunner.isWatching, isTrue);
+        expect(devServerRunner.isServerRunning, isTrue);
+        expect(devServerRunner.isCompleted, isFalse);
+
+        await controller.close();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(devServerRunner.isWatching, isFalse);
+        expect(devServerRunner.isServerRunning, isFalse);
+        expect(devServerRunner.isCompleted, isTrue);
+        await expectLater(
+          devServerRunner.exitCode,
+          completion(ExitCode.success),
+        );
+      });
+
+      test('completes dev server when watcher ends with error', () async {
+        final controller = StreamController<WatchEvent>();
+        when(() => process.stdout).thenAnswer(
+          (_) => Stream.value(
+            utf8.encode('[hotreload] hot reload enabled.'),
+          ),
+        );
+        when(() => directoryWatcher.events)
+            .thenAnswer((_) => controller.stream);
+        await expectLater(devServerRunner.start(), completes);
+
+        expect(devServerRunner.isWatching, isTrue);
+        expect(devServerRunner.isServerRunning, isTrue);
+        expect(devServerRunner.isCompleted, isFalse);
+
+        controller.addError(Exception('error'));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(devServerRunner.isWatching, isFalse);
+        expect(devServerRunner.isServerRunning, isFalse);
+        expect(devServerRunner.isCompleted, isTrue);
+        await expectLater(
+          devServerRunner.exitCode,
+          completion(ExitCode.software),
+        );
+      });
+
+      test(
+        '''
+runs codegen with debounce when changes are made to the public or routes directory''',
+        () async {
+          final controller = StreamController<WatchEvent>();
+          when(() => process.stdout).thenAnswer(
+            (_) => Stream.value(utf8.encode('[hotreload] hot reload enabled.')),
+          );
+          when(() => directoryWatcher.events)
+              .thenAnswer((_) => controller.stream);
+
+          await expectLater(devServerRunner.start(), completes);
+
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+
+          verify(
+            () => generator.generate(
+              any(),
+              vars: any(named: 'vars'),
+              fileConflictResolution: FileConflictResolution.overwrite,
+            ),
+          ).called(1);
+
+          controller
+            ..add(
+              WatchEvent(
+                ChangeType.ADD,
+                path.join(Directory.current.path, 'routes', 'users.dart'),
+              ),
+            )
+            ..add(
+              WatchEvent(
+                ChangeType.REMOVE,
+                path.join(Directory.current.path, 'routes', 'user.dart'),
+              ),
+            );
+
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+
+          verify(
+            () => generator.generate(
+              any(),
+              vars: any(named: 'vars'),
+              fileConflictResolution: FileConflictResolution.overwrite,
+            ),
+          ).called(1);
+
+          controller.add(
+            WatchEvent(
+              ChangeType.MODIFY,
+              path.join(Directory.current.path, 'public', 'hello.txt'),
+            ),
+          );
+
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+
+          verify(
+            () => generator.generate(
+              any(),
+              vars: any(named: 'vars'),
+              fileConflictResolution: FileConflictResolution.overwrite,
+            ),
+          ).called(1);
+
+          controller.add(
+            WatchEvent(
+              ChangeType.MODIFY,
+              path.join(Directory.current.path, 'tmp', 'message.txt'),
+            ),
+          );
+
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          verifyNever(
+            () => generator.generate(
+              any(),
+              vars: any(named: 'vars'),
+              fileConflictResolution: FileConflictResolution.overwrite,
+            ),
+          );
         },
-        sigint: sigint,
-        runProcess: (String executable, List<String> arguments) async {
-          processRunCalls.add([executable, ...arguments]);
-          return processResult;
+      );
+
+      test('runs codegen when changes are made to main.dart', () async {
+        final controller = StreamController<WatchEvent>();
+        when(() => process.stdout).thenAnswer(
+          (_) => Stream.value(utf8.encode('[hotreload] hot reload enabled.')),
+        );
+        when(() => directoryWatcher.events)
+            .thenAnswer((_) => controller.stream);
+
+        await expectLater(devServerRunner.start(), completes);
+
+        verify(
+          () => generator.generate(
+            any(),
+            vars: any(named: 'vars'),
+            fileConflictResolution: FileConflictResolution.overwrite,
+          ),
+        ).called(1);
+
+        controller.add(
+          WatchEvent(
+            ChangeType.ADD,
+            path.join(Directory.current.path, 'main.dart'),
+          ),
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        verify(
+          () => generator.generate(
+            any(),
+            vars: any(named: 'vars'),
+            fileConflictResolution: FileConflictResolution.overwrite,
+          ),
+        ).called(1);
+      });
+
+      test('runs codegen when changes are made to pubspec.yaml', () async {
+        final controller = StreamController<WatchEvent>();
+
+        when(() => process.stdout).thenAnswer(
+          (_) => Stream.value(utf8.encode('[hotreload] hot reload enabled.')),
+        );
+
+        when(() => directoryWatcher.events)
+            .thenAnswer((_) => controller.stream);
+
+        await expectLater(devServerRunner.start(), completes);
+
+        verify(
+          () => generator.generate(
+            any(),
+            vars: any(named: 'vars'),
+            fileConflictResolution: FileConflictResolution.overwrite,
+          ),
+        ).called(1);
+
+        controller.add(
+          WatchEvent(
+            ChangeType.MODIFY,
+            path.join(Directory.current.path, 'pubspec.yaml'),
+          ),
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        verify(
+          () => generator.generate(
+            any(),
+            vars: any(named: 'vars'),
+            fileConflictResolution: FileConflictResolution.overwrite,
+          ),
+        ).called(1);
+      });
+
+      test(
+        'caches snapshot when hot reload runs successfully',
+        () async {
+          when(() => process.stdout).thenAnswer(
+            (_) => Stream.value(utf8.encode('[hotreload] hot reload enabled.')),
+          );
+
+          await expectLater(devServerRunner.start(), completes);
+
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+
+          verify(() => generatorTarget.cacheLatestSnapshot()).called(1);
         },
       );
 
-      devServerRunner.start().ignore();
-      await untilCalled(() => process.pid);
-      expect(exitCode, equals(1));
-      expect(
-        processRunCalls,
-        equals([
-          ['taskkill', '/F', '/T', '/PID', '$processId']
-        ]),
-      );
-      verifyNever(() => process.kill());
-    },
-  );
+      test(
+        'restores previous snapshot when hot reload fails.',
+        () async {
+          final stdoutController = StreamController<List<int>>();
+          final stderrController = StreamController<List<int>>();
 
-  test(
-    'dont kills process if a warning occurs before '
-    'hotreload is enabled',
-    () async {
-      const warningMessage = """
+          when(() => generatorTarget.rollback()).thenAnswer((_) async {});
+          when(() => process.stdout).thenAnswer((_) => stdoutController.stream);
+          when(() => process.stderr).thenAnswer((_) => stderrController.stream);
+
+          await expectLater(devServerRunner.start(), completes);
+
+          stdoutController.add(utf8.encode('[hotreload] hot reload enabled'));
+          await untilCalled(() => generatorTarget.cacheLatestSnapshot());
+
+          const error = 'something went wrong';
+
+          stderrController.add(utf8.encode(error));
+          await untilCalled(() => generatorTarget.rollback());
+
+          await stderrController.close();
+          await stdoutController.close();
+
+          verify(() => generatorTarget.cacheLatestSnapshot()).called(1);
+          verify(() => generatorTarget.rollback()).called(1);
+          verify(() => logger.err(error)).called(1);
+        },
+      );
+    });
+
+    group('process runtime', () {
+      test(
+        'kills all child processes when sigint received on windows',
+        () async {
+          final processRunCalls = <List<String>>[];
+
+          when(
+            () => directoryWatcher.events,
+          ).thenAnswer((_) => StreamController<WatchEvent>().stream);
+          when(() => sigint.watch()).thenAnswer((_) => Stream.value(sigint));
+
+          devServerRunner = DevServerRunner(
+            logger: logger,
+            port: port,
+            devServerBundleGenerator: generator,
+            dartVmServicePort: dartVmServicePort,
+            workingDirectory: Directory.current,
+            directoryWatcher: (_) => directoryWatcher,
+            isWindows: true,
+            startProcess: (_, __, {runInShell = false}) async => process,
+            sigint: sigint,
+            runProcess: (String executable, List<String> arguments) async {
+              processRunCalls.add([executable, ...arguments]);
+              return processResult;
+            },
+          );
+
+          await expectLater(devServerRunner.start(), completes);
+
+          await untilCalled(() => process.pid);
+          final exitCode = await devServerRunner.exitCode;
+
+          expect(exitCode.code, equals(0));
+          expect(
+            processRunCalls,
+            equals([
+              ['taskkill', '/F', '/T', '/PID', '$processId']
+            ]),
+          );
+          verifyNever(() => process.kill());
+        },
+      );
+
+      test(
+        'completes dev server if server process is killed externally',
+        () async {
+          final completer = Completer<int>();
+          when(() => process.exitCode).thenAnswer((_) => completer.future);
+
+          final controller = StreamController<WatchEvent>();
+          when(() => directoryWatcher.events)
+              .thenAnswer((_) => controller.stream);
+
+          await expectLater(devServerRunner.start(), completes);
+
+          completer.complete(0);
+          await Future<void>.delayed(Duration.zero);
+
+          verify(
+            () => logger.info('[process] server process has been terminated'),
+          ).called(1);
+          verify(() => process.kill()).called(1);
+          await expectLater(
+            devServerRunner.exitCode,
+            completion(ExitCode.unavailable),
+          );
+        },
+      );
+
+      test(
+        'completes dev server when watcher is finished',
+        () async {
+          final completer = Completer<int>();
+          when(() => process.exitCode).thenAnswer((_) => completer.future);
+
+          final controller = StreamController<WatchEvent>();
+          when(() => directoryWatcher.events)
+              .thenAnswer((_) => controller.stream);
+
+          await expectLater(devServerRunner.start(), completes);
+          await controller.close();
+          await Future<void>.delayed(Duration.zero);
+
+          expect(devServerRunner.isCompleted, isTrue);
+
+          completer.complete(0);
+          await Future<void>.delayed(Duration.zero);
+
+          verifyNever(
+            () => logger.info('[process] server process has been terminated'),
+          );
+          await expectLater(
+            devServerRunner.exitCode,
+            completion(ExitCode.success),
+          );
+        },
+      );
+
+      test(
+        '''kills process if error occurs before hot reload is enabled on non-windows''',
+        () async {
+          final processRunCalls = <List<String>>[];
+
+          when(() => process.stderr).thenAnswer(
+            (_) => Stream.value(utf8.encode('oops')),
+          );
+          when(() => process.kill()).thenReturn(true);
+          when(
+            () => directoryWatcher.events,
+          ).thenAnswer((_) => StreamController<WatchEvent>().stream);
+          when(() => sigint.watch()).thenAnswer((_) => const Stream.empty());
+
+          devServerRunner = DevServerRunner(
+            logger: logger,
+            port: port,
+            devServerBundleGenerator: generator,
+            dartVmServicePort: dartVmServicePort,
+            workingDirectory: Directory.current,
+            directoryWatcher: (_) => directoryWatcher,
+            startProcess: (_, __, {runInShell = false}) async => process,
+            sigint: sigint,
+            runProcess: (String executable, List<String> arguments) async {
+              processRunCalls.add([executable, ...arguments]);
+              return processResult;
+            },
+          );
+
+          await expectLater(devServerRunner.start(), completes);
+          final exitCode = await devServerRunner.exitCode;
+
+          expect(exitCode.code, equals(70));
+          expect(processRunCalls, isEmpty);
+          verify(() => process.kill()).called(1);
+        },
+      );
+
+      test(
+        '''
+Does not kill process if a warning occurs before hot reload is enabled''',
+        () async {
+          const warningMessage = """
 lib/my_model.g.dart:53:20: Warning: Operand of null-aware operation '!' has type 'String' which excludes null.
           ? _value.name!
                    ^
           """;
-      final generatorHooks = _MockGeneratorHooks();
-      when(
-        () => generatorHooks.preGen(
-          vars: any(named: 'vars'),
-          workingDirectory: any(named: 'workingDirectory'),
-          onVarsChanged: any(named: 'onVarsChanged'),
-        ),
-      ).thenAnswer((invocation) async {
-        (invocation.namedArguments[const Symbol('onVarsChanged')] as void
-                Function(Map<String, dynamic> vars))
-            .call(<String, dynamic>{});
-      });
-      when(
-        () => generator.generate(
-          any(),
-          vars: any(named: 'vars'),
-          fileConflictResolution: FileConflictResolution.overwrite,
-        ),
-      ).thenAnswer((_) async => []);
-      when(() => generator.hooks).thenReturn(generatorHooks);
-      when(() => process.stdout).thenAnswer((_) => const Stream.empty());
-      when(() => process.stderr).thenAnswer(
-        (_) => Stream.value(
-          utf8.encode(warningMessage),
-        ),
-      );
-      when(
-        () => directoryWatcher.events,
-      ).thenAnswer(
-        (_) => Stream.value(WatchEvent(ChangeType.MODIFY, 'README.md')),
-      );
-      devServerRunner = DevServerRunner(
-        logger: logger,
-        port: port,
-        devServerBundleGenerator: generator,
-        dartVmServicePort: dartVmServicePort,
-        workingDirectory: Directory.current,
-        // test
 
-        directoryWatcher: (_) => directoryWatcher,
-        startProcess: (
-          String executable,
-          List<String> arguments, {
-          bool runInShell = false,
-        }) async {
-          return process;
-        },
-        sigint: sigint,
-      );
+          when(() => process.stderr).thenAnswer(
+            (_) => Stream.value(utf8.encode(warningMessage)),
+          );
+          when(() => directoryWatcher.events).thenAnswer(
+            (_) => Stream.value(WatchEvent(ChangeType.MODIFY, 'README.md')),
+          );
+          devServerRunner = DevServerRunner(
+            logger: logger,
+            port: port,
+            devServerBundleGenerator: generator,
+            dartVmServicePort: dartVmServicePort,
+            workingDirectory: Directory.current,
+            directoryWatcher: (_) => directoryWatcher,
+            startProcess: (_, __, {runInShell = false}) async => process,
+            sigint: sigint,
+          );
 
-      final exitCode = await devServerRunner.start();
-      expect(exitCode, equals(ExitCode.success));
-      verify(
-        () => generatorHooks.preGen(
-          vars: <String, dynamic>{'port': '8080'},
-          workingDirectory: any(named: 'workingDirectory'),
-          onVarsChanged: any(named: 'onVarsChanged'),
-        ),
-      ).called(1);
-      verifyNever(() => process.kill());
-      verify(() => logger.warn(warningMessage.trim())).called(1);
-    },
-  );
+          await expectLater(devServerRunner.start(), completes);
 
-  test(
-    'kills process if error occurs before '
-    'hotreload is enabled on non-windows',
-    () async {
-      final generatorHooks = _MockGeneratorHooks();
-      final processRunCalls = <List<String>>[];
-      int? exitCode;
-      when(
-        () => generatorHooks.preGen(
-          vars: any(named: 'vars'),
-          workingDirectory: any(named: 'workingDirectory'),
-          onVarsChanged: any(named: 'onVarsChanged'),
-        ),
-      ).thenAnswer((invocation) async {
-        (invocation.namedArguments[const Symbol('onVarsChanged')] as void
-                Function(Map<String, dynamic> vars))
-            .call(<String, dynamic>{});
-      });
-      when(
-        () => generator.generate(
-          any(),
-          vars: any(named: 'vars'),
-          fileConflictResolution: FileConflictResolution.overwrite,
-        ),
-      ).thenAnswer((_) async => []);
-      when(() => generator.hooks).thenReturn(generatorHooks);
-      when(() => process.stdout).thenAnswer((_) => const Stream.empty());
-      when(() => process.stderr).thenAnswer(
-        (_) => Stream.value(utf8.encode('oops')),
-      );
-      when(() => process.kill()).thenReturn(true);
-      when(
-        () => directoryWatcher.events,
-      ).thenAnswer((_) => StreamController<WatchEvent>().stream);
-      when(() => sigint.watch()).thenAnswer((_) => const Stream.empty());
-      devServerRunner = DevServerRunner(
-        logger: logger,
-        port: port,
-        devServerBundleGenerator: generator,
-        dartVmServicePort: dartVmServicePort,
-        workingDirectory: Directory.current,
-        // test
+          await untilCalled(() => logger.warn(warningMessage.trim()));
+          verifyNever(() => process.kill());
 
-        directoryWatcher: (_) => directoryWatcher,
-        exit: (code) => exitCode = code,
-        startProcess: (
-          String executable,
-          List<String> arguments, {
-          bool runInShell = false,
-        }) async {
-          return process;
-        },
-        sigint: sigint,
-        runProcess: (String executable, List<String> arguments) async {
-          processRunCalls.add([executable, ...arguments]);
-          return processResult;
+          verify(
+            () => generatorHooks.preGen(
+              vars: <String, dynamic>{'port': '8080'},
+              workingDirectory: any(named: 'workingDirectory'),
+              onVarsChanged: any(named: 'onVarsChanged'),
+            ),
+          ).called(1);
         },
       );
 
-      devServerRunner.start().ignore();
-      await untilCalled(() => process.kill());
-      expect(exitCode, equals(1));
-      expect(processRunCalls, isEmpty);
-      verify(() => process.kill()).called(1);
-    },
-  );
+      test(
+        'kills process with message when Dart VM is already in use',
+        () async {
+          final processRunCalls = <List<String>>[];
 
-  test(
-    'kills process with helpful message when Dart VM is already in use',
-    () async {
-      final generatorHooks = _MockGeneratorHooks();
-      final processRunCalls = <List<String>>[];
-      int? exitCode;
-      when(
-        () => generatorHooks.preGen(
-          vars: any(named: 'vars'),
-          workingDirectory: any(named: 'workingDirectory'),
-          onVarsChanged: any(named: 'onVarsChanged'),
-        ),
-      ).thenAnswer((invocation) async {
-        (invocation.namedArguments[const Symbol('onVarsChanged')] as void
-                Function(Map<String, dynamic> vars))
-            .call(<String, dynamic>{});
-      });
-      when(
-        () => generator.generate(
-          any(),
-          vars: any(named: 'vars'),
-          fileConflictResolution: FileConflictResolution.overwrite,
-        ),
-      ).thenAnswer((_) async => []);
-      when(() => generator.hooks).thenReturn(generatorHooks);
-      when(() => process.stdout).thenAnswer((_) => const Stream.empty());
-      const errorMessage =
-          'Could not start the VM service: localhost:8181 is already in use.';
-      when(() => process.stderr).thenAnswer(
-        (_) => Stream.value(utf8.encode(errorMessage)),
-      );
-      when(() => process.kill()).thenReturn(true);
-      when(
-        () => directoryWatcher.events,
-      ).thenAnswer((_) => StreamController<WatchEvent>().stream);
-      when(() => sigint.watch()).thenAnswer((_) => const Stream.empty());
-      devServerRunner = DevServerRunner(
-        logger: logger,
-        port: port,
-        devServerBundleGenerator: generator,
-        dartVmServicePort: dartVmServicePort,
-        workingDirectory: Directory.current,
-        // test
+          const errorMessage = '''
+Could not start the VM service: localhost:8181 is already in use.''';
+          when(() => process.stderr).thenAnswer(
+            (_) => Stream.value(utf8.encode(errorMessage)),
+          );
+          when(() => process.kill()).thenReturn(true);
+          when(
+            () => directoryWatcher.events,
+          ).thenAnswer((_) => StreamController<WatchEvent>().stream);
+          when(() => sigint.watch()).thenAnswer((_) => const Stream.empty());
+          devServerRunner = DevServerRunner(
+            logger: logger,
+            port: port,
+            devServerBundleGenerator: generator,
+            dartVmServicePort: dartVmServicePort,
+            workingDirectory: Directory.current,
+            directoryWatcher: (_) => directoryWatcher,
+            startProcess: (_, __, {runInShell = false}) async => process,
+            sigint: sigint,
+            runProcess: (String executable, List<String> arguments) async {
+              processRunCalls.add([executable, ...arguments]);
+              return processResult;
+            },
+          );
 
-        directoryWatcher: (_) => directoryWatcher,
-        exit: (code) => exitCode = code,
-        startProcess: (
-          String executable,
-          List<String> arguments, {
-          bool runInShell = false,
-        }) async {
-          return process;
-        },
-        sigint: sigint,
-        runProcess: (String executable, List<String> arguments) async {
-          processRunCalls.add([executable, ...arguments]);
-          return processResult;
+          await expectLater(devServerRunner.start(), completes);
+          final exitCode = await devServerRunner.exitCode;
+
+          expect(
+            exitCode.code,
+            equals(70),
+            reason: 'Should exit when VM service is already in use.',
+          );
+          expect(
+            processRunCalls,
+            isEmpty,
+            reason: 'Should not run the serve process.',
+          );
+          verify(() => process.kill()).called(1);
+          verify(
+            () => logger.err(
+              '$errorMessage '
+              '''Try specifying a different port using the `--dart-vm-service-port` argument when running `dart_frog dev`.''',
+            ),
+          ).called(1);
         },
       );
-
-      devServerRunner.start().ignore();
-      await untilCalled(() => process.kill());
-      expect(
-        exitCode,
-        equals(1),
-        reason: 'Should exit when VM service is already in use.',
-      );
-      expect(
-        processRunCalls,
-        isEmpty,
-        reason: 'Should not run the serve process.',
-      );
-      verify(() => process.kill()).called(1);
-      verify(
-        () => logger.err(
-          '$errorMessage '
-          '''Try specifying a different port using the `--dart-vm-service-port` argument when running `dart_frog dev`.''',
-        ),
-      ).called(1);
-    },
-  );
+    });
+  });
 }


### PR DESCRIPTION


## Description

This PR comes after #729. 

Unlike #729, this is a significant change in how the dev server is/can be managed by the dev command and other tools. 

It introduces two new methods:

- Reload: After the dev server starts, re-run the codegen
- Stop: Stops the dev server. To keep the same pattern as found on `dart:io `(`Process`), `dart:async` (`Completer`) and in the flutter daemon, when completed, the dev server instance cannot be restarted.

This is part of https://github.com/VeryGoodOpenSource/dart_frog/issues/705


## Type of Change


- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
