### PR TITLE
refactor(bearer_authentication): lint warnings on auth examples

### DIFF
--- a/.github/workflows/examples_basic_authentication.yaml
+++ b/.github/workflows/examples_basic_authentication.yaml
@@ -31,10 +31,10 @@ jobs:
       report_on: "routes"
 
   docker:
+    if: false
     uses: ./.github/workflows/.docker_tests.yaml
     with:
       # TODO(erickzanardo): temporarirly disabled while dart_frog_auth is
       # no published yet.
-      if: false
       setup: rm pubspec_overrides.yaml && dart pub global activate --source path ../../packages/dart_frog_cli
       working_directory: examples/basic_authentication

--- a/.github/workflows/examples_bearer_authentication.yaml
+++ b/.github/workflows/examples_bearer_authentication.yaml
@@ -31,10 +31,10 @@ jobs:
       report_on: "routes"
 
   docker:
+    if: false
     uses: ./.github/workflows/.docker_tests.yaml
     with:
       # TODO(erickzanardo): temporarirly disabled while dart_frog_auth is
       # no published yet.
-      if: false
       setup: rm pubspec_overrides.yaml && dart pub global activate --source path ../../packages/dart_frog_cli
       working_directory: examples/bearer_authentication

--- a/examples/bearer_authentication/routes/auth/_middleware.dart
+++ b/examples/bearer_authentication/routes/auth/_middleware.dart
@@ -4,7 +4,7 @@ import 'package:dart_frog/dart_frog.dart';
 
 Handler middleware(Handler handler) {
   final userRepository = UserRepository();
-  final sessionRepository = SessionRepository();
+  const sessionRepository = SessionRepository();
 
   return handler
       .use(requestLogger())

--- a/examples/bearer_authentication/routes/users/_middleware.dart
+++ b/examples/bearer_authentication/routes/users/_middleware.dart
@@ -14,7 +14,7 @@ Future<User?> Function(String) userFromToken({
 
 Handler middleware(Handler handler) {
   final userRepository = UserRepository();
-  final sessionRepository = SessionRepository();
+  const sessionRepository = SessionRepository();
 
   return handler
       .use(requestLogger())


### PR DESCRIPTION


## Status

**READY**

## Description

The workflows are silently (thanks to GitHub) failing due to a minor syntax error. Some lint warnings went trough

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
