### PR TITLE
fix(vscode): alter when command menu palette commands show

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -59,17 +59,17 @@
         {
           "command": "extension.new-route",
           "group": "dartFrogGroup@1",
-          "when": "resourceDirname =~ /routes/ && (explorerResourceIsFolder || resourceExtname == .dart)"
+          "when": "(resourceDirname =~ /routes/ && (explorerResourceIsFolder || resourceExtname == .dart)) || (explorerResourceIsFolder && resourceFilename == routes)"
         },
         {
           "command": "extension.new-middleware",
           "group": "dartFrogGroup@1",
-          "when": "resourceDirname =~ /routes/ && (explorerResourceIsFolder || resourceExtname == .dart)"
+          "when": "(resourceDirname =~ /routes/ && (explorerResourceIsFolder || resourceExtname == .dart)) || (explorerResourceIsFolder && resourceFilename == routes)"
         },
         {
           "command": "extension.create",
           "group": "dartFrogGroup@2",
-          "when": "!(resourceDirname =~ /routes/)"
+          "when": "!(resourceDirname =~ /routes/) && !(explorerResourceIsFolder && resourceFilename == routes)"
         }
       ]
     }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Changes the when clause to allow new commands to prompt when _routes_ directory is selected.

> Note: This is a quick fix, ideally we would check if the project is actually a Dart Frog project. This will be amended in a different Pull Request where we will also restrict commands showing if the window is not opened at the root of a Dart Frog project.

## Demonstration

After:

https://github.com/VeryGoodOpenSource/dart_frog/assets/44524995/4033e079-ed46-44bb-a2b1-483ef51a121c

Before:

https://github.com/VeryGoodOpenSource/dart_frog/assets/44524995/2c1178e5-4bf8-4fc0-ab8c-4a0c0aeaede5

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
