### PR TITLE
refactor(vscode): use string over String

### DIFF
--- a/extensions/vscode/src/commands/create.ts
+++ b/extensions/vscode/src/commands/create.ts
@@ -99,7 +99,7 @@ function promptProjectName(value: string): Thenable<string | undefined> {
 }
 
 async function executeDartFrogCreateCommand(
-  outputDirectory: String,
+  outputDirectory: string,
   projectName: string
 ): Promise<void> {
   return cp.exec(
@@ -107,7 +107,7 @@ async function executeDartFrogCreateCommand(
     {
       cwd: outputDirectory,
     },
-    function (error: Error, stdout: String, stderr: String) {
+    function (error: Error, stdout: string, stderr: string) {
       if (error) {
         window.showErrorMessage(error.message);
       }

--- a/extensions/vscode/src/commands/install-cli.ts
+++ b/extensions/vscode/src/commands/install-cli.ts
@@ -25,7 +25,7 @@ export const installCLI = async (): Promise<void> => {
 async function installDartFrogCliVersion(): Promise<void> {
   await cp.exec(
     `dart pub global activate dart_frog_cli`,
-    function (error: Error, stdout: String, stderr: String) {
+    function (error: Error, stdout: string, stderr: string) {
       if (error) {
         window.showErrorMessage(error.message);
       }

--- a/extensions/vscode/src/commands/new-middleware.ts
+++ b/extensions/vscode/src/commands/new-middleware.ts
@@ -126,18 +126,18 @@ function promptRoutePath(routePath: string): Thenable<string | undefined> {
  * Runs the `dart_frog new middleware` command with the given route path.
  *
  * @param {string} routePath, the path of the new middleware.
- * @param {String} dartFrogProjectPath, the root of the Dart Frog project.
+ * @param {string} dartFrogProjectPath, the root of the Dart Frog project.
  */
 function executeDartFrogNewMiddlewareCommand(
-  routePath: String,
-  dartFrogProjectPath: String
+  routePath: string,
+  dartFrogProjectPath: string
 ): void {
   cp.exec(
     `dart_frog new middleware '${routePath}'`,
     {
       cwd: dartFrogProjectPath,
     },
-    function (error: Error, stdout: String, stderr: String) {
+    function (error: Error, stdout: string, stderr: string) {
       if (error) {
         window.showErrorMessage(error.message);
       }

--- a/extensions/vscode/src/commands/new-route.ts
+++ b/extensions/vscode/src/commands/new-route.ts
@@ -123,18 +123,18 @@ async function promptForTargetDirectory(): Promise<string | undefined> {
  * Runs the `dart_frog new route` command with the given route path.
  *
  * @param {string} routePath, the path of the new route.
- * @param {String} dartFrogProjectPath, the root of the Dart Frog project.
+ * @param {string} dartFrogProjectPath, the root of the Dart Frog project.
  */
 function executeDartFrogNewRouteCommand(
-  routePath: String,
-  dartFrogProjectPath: String
+  routePath: string,
+  dartFrogProjectPath: string
 ): void {
   cp.exec(
     `dart_frog new route '${routePath}'`,
     {
       cwd: dartFrogProjectPath,
     },
-    function (error: Error, stdout: String, stderr: String) {
+    function (error: Error, stdout: string, stderr: string) {
       if (error) {
         window.showErrorMessage(error.message);
       }

--- a/extensions/vscode/src/commands/update-cli.ts
+++ b/extensions/vscode/src/commands/update-cli.ts
@@ -29,7 +29,7 @@ export const updateCLI = async (): Promise<void> => {
 async function updateDartFrogCLIVersion(): Promise<void> {
   await cp.exec(
     `dart_frog update`,
-    function (error: Error, stdout: String, stderr: String) {
+    function (error: Error, stdout: string, stderr: string) {
       if (error) {
         window.showErrorMessage(error.message);
       }

--- a/extensions/vscode/src/utils/cli-version.ts
+++ b/extensions/vscode/src/utils/cli-version.ts
@@ -11,10 +11,10 @@ const compatibleCLIVersion = ">=0.3.7 <2.0.0";
 /**
  * Collects the version of Dart Frog CLI installed in the user's system.
  *
- * @returns {String | undefined} The semantic version of Dart Frog CLI installed
+ * @returns {string | undefined} The semantic version of Dart Frog CLI installed
  * in the user's system, or null if Dart Frog CLI is not installed.
  */
-export function readDartFrogCLIVersion(): String | undefined {
+export function readDartFrogCLIVersion(): string | undefined {
   try {
     const result = cp.execSync(`dart_frog --version`);
     const decodedResult = new TextDecoder().decode(result);
@@ -27,10 +27,10 @@ export function readDartFrogCLIVersion(): String | undefined {
 /**
  * Collects the latest available version of Dart Frog CLI.
  *
- * @returns {String | undefined} The latest available semantic version of
+ * @returns {string | undefined} The latest available semantic version of
  * Dart Frog CLI, or undefined if Dart Frog CLI is not installed.
  */
-export function readLatestDartFrogCLIVersion(): String | undefined {
+export function readLatestDartFrogCLIVersion(): string | undefined {
   try {
     const result = cp.execSync(`dart_frog --version`);
     const decodedResult = new TextDecoder().decode(result);
@@ -48,13 +48,13 @@ export function readLatestDartFrogCLIVersion(): String | undefined {
  * Checks if the version of Dart Frog CLI installed in the user's system is
  * compatible with this extension.
  *
- * @param {String} version The semantic version of Dart Frog CLI installed in
+ * @param {string} version The semantic version of Dart Frog CLI installed in
  * the user's system.
  * @returns {Boolean} True if the version of Dart Frog CLI installed in the
  * user's system is compatible with this extension, false otherwise.
  * @see {@link readDartFrogCLIVersion}, to collect the version of Dart Frog CLI.
  */
-export function isCompatibleDartFrogCLIVersion(version: String): Boolean {
+export function isCompatibleDartFrogCLIVersion(version: string): Boolean {
   return semver.satisfies(version, compatibleCLIVersion);
 }
 
@@ -71,10 +71,10 @@ export function isDartFrogCLIInstalled(): boolean {
 /**
  * Opens the changelog for the specified version in a browser.
  *
- * @param {String} version The semantic version of Dart Frog CLI which changelog
+ * @param {string} version The semantic version of Dart Frog CLI which changelog
  * is requested to open.
  */
-export async function openChangelog(version: String): Promise<void> {
+export async function openChangelog(version: string): Promise<void> {
   vscode.commands.executeCommand(
     "vscode.open",
     vscode.Uri.parse(

--- a/extensions/vscode/src/utils/dart-frog-structure.ts
+++ b/extensions/vscode/src/utils/dart-frog-structure.ts
@@ -22,8 +22,8 @@ import { window, workspace } from "vscode";
  * project from a file path.
  */
 export function normalizeRoutePath(
-  selectedPath: String,
-  dartFrogProjectPath: String
+  selectedPath: string,
+  dartFrogProjectPath: string
 ): string {
   const routesPath = path.join(dartFrogProjectPath, "routes");
   if (!selectedPath.startsWith(routesPath)) {
@@ -62,7 +62,7 @@ export function normalizeRoutePath(
  * @see {@link isDartFrogProject}, to determine if a file is a Dart Frog
  * project.
  */
-export function nearestDartFrogProject(filePath: String): String | undefined {
+export function nearestDartFrogProject(filePath: string): string | undefined {
   let currentPath = filePath;
   while (currentPath !== path.sep) {
     if (isDartFrogProject(currentPath)) {
@@ -88,7 +88,7 @@ export function nearestDartFrogProject(filePath: String): String | undefined {
  * @returns {boolean} Whether or not the {@link filePath} is the root of Dart
  * Frog project.
  */
-export function isDartFrogProject(filePath: String): boolean {
+export function isDartFrogProject(filePath: string): boolean {
   const routesPath = path.join(filePath, "routes");
   const pubspecPath = path.join(filePath, "pubspec.yaml");
 
@@ -123,8 +123,8 @@ export function isDartFrogProject(filePath: String): boolean {
  */
 export function resolveDartFrogProjectPathFromWorkspace(
   _nearestDartFrogProject: (
-    filePath: String
-  ) => String | undefined = nearestDartFrogProject
+    filePath: string
+  ) => string | undefined = nearestDartFrogProject
 ): string | undefined {
   if (window.activeTextEditor) {
     const currentTextEditorPath = path.normalize(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

When creating a string using `foo = "bar"` the type of foo is `string`. In most cases there is no need to use `String` as the VS Code API accepts `string` primitives.

See [TypeScript Documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#general-types), which does not recommend the use of `String`:

> Don’t ever use the types Number, String, Boolean, Symbol, or Object These types refer to non-primitive boxed objects that are almost never used appropriately in JavaScript code.

Changes:
- Replaces occurrences of "String" with "string"

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
