### PR TITLE
test(dart_frog_cli): mock stdin in the command run level

### DIFF
--- a/packages/dart_frog_cli/e2e/test/new_test.dart
+++ b/packages/dart_frog_cli/e2e/test/new_test.dart
@@ -356,8 +356,10 @@ void main() {
       );
 
       expect(
-        fileAt('prefix/[existing_dynamic_route]/index.dart',
-            on: routesDirectory),
+        fileAt(
+          'prefix/[existing_dynamic_route]/index.dart',
+          on: routesDirectory,
+        ),
         exists,
       );
 

--- a/packages/dart_frog_cli/lib/src/command.dart
+++ b/packages/dart_frog_cli/lib/src/command.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
+import 'package:dart_frog_cli/src/command_runner.dart';
 import 'package:mason/mason.dart';
 import 'package:meta/meta.dart';
 
@@ -22,6 +23,12 @@ abstract class DartFrogCommand extends Command<int> {
 
   /// Current working directory used for testing purposes only.
   Directory? testCwd;
+
+  /// [stdin] used for testing purposes only.
+  Stdin? testStdin;
+
+  /// The [Stdin] instance to be used by the commands.
+  Stdin get stdin => testStdin ?? (runner as DartFrogCommandRunner?)!.stdin;
 
   /// [ArgResults] for the current command.
   ArgResults get results => testArgResults ?? argResults!;

--- a/packages/dart_frog_cli/lib/src/command_runner.dart
+++ b/packages/dart_frog_cli/lib/src/command_runner.dart
@@ -32,10 +32,12 @@ class DartFrogCommandRunner extends CompletionCommandRunner<int> {
     PubUpdater? pubUpdater,
     io.ProcessSignal? sigint,
     Exit? exit,
+    io.Stdin? stdin,
   })  : _logger = logger ?? Logger(),
         _pubUpdater = pubUpdater ?? PubUpdater(),
         _sigint = sigint ?? io.ProcessSignal.sigint,
         _exit = exit ?? io.exit,
+        stdin = stdin ?? io.stdin,
         super(executableName, executableDescription) {
     argParser.addFlags();
     addCommand(BuildCommand(logger: _logger));
@@ -52,6 +54,9 @@ class DartFrogCommandRunner extends CompletionCommandRunner<int> {
   final PubUpdater _pubUpdater;
   final io.ProcessSignal _sigint;
   final Exit _exit;
+
+  /// The [io.Stdin] instance to be used by the commands.
+  final io.Stdin stdin;
 
   @override
   Future<int> run(Iterable<String> args) async {

--- a/packages/dart_frog_cli/lib/src/commands/dev/dev.dart
+++ b/packages/dart_frog_cli/lib/src/commands/dev/dev.dart
@@ -20,12 +20,11 @@ class DevCommand extends DartFrogCommand {
     DevServerRunnerBuilder? devServerRunnerBuilder,
     runtime_compatibility.RuntimeCompatibilityCallback?
         ensureRuntimeCompatibility,
-    io.Stdin? stdin,
   })  : _ensureRuntimeCompatibility = ensureRuntimeCompatibility ??
             runtime_compatibility.ensureRuntimeCompatibility,
         _generator = generator ?? MasonGenerator.fromBundle,
-        _devServerRunnerBuilder = devServerRunnerBuilder ?? DevServerRunner.new,
-        _stdin = stdin ?? io.stdin {
+        _devServerRunnerBuilder =
+            devServerRunnerBuilder ?? DevServerRunner.new {
     argParser
       ..addOption(
         'port',
@@ -47,7 +46,6 @@ class DevCommand extends DartFrogCommand {
   final DevServerRunnerBuilder _devServerRunnerBuilder;
   final runtime_compatibility.RuntimeCompatibilityCallback
       _ensureRuntimeCompatibility;
-  final io.Stdin _stdin;
 
   @override
   final String description = 'Run a local development server.';
@@ -61,14 +59,14 @@ class DevCommand extends DartFrogCommand {
 
   void _startListeningForHelpers() {
     if (_stdinSubscription != null) return;
-    if (!_stdin.hasTerminal) return;
+    if (!stdin.hasTerminal) return;
 
     // listen for the R key
-    _stdin
+    stdin
       ..echoMode = false
       ..lineMode = false;
 
-    _stdinSubscription = _stdin.listen(
+    _stdinSubscription = stdin.listen(
       (event) {
         if (event.length == 1 && event.first == 'R'.codeUnitAt(0)) {
           _devServerRunner.reload();
@@ -94,9 +92,9 @@ class DevCommand extends DartFrogCommand {
     // devserver started.
     // That is why this check is made after the subscription
     // is canceled, if existent.
-    if (!_stdin.hasTerminal) return;
+    if (!stdin.hasTerminal) return;
 
-    _stdin
+    stdin
       ..lineMode = true
       ..echoMode = true;
   }

--- a/packages/dart_frog_cli/test/src/command_runner_test.dart
+++ b/packages/dart_frog_cli/test/src/command_runner_test.dart
@@ -17,6 +17,8 @@ class _MockPubUpdater extends Mock implements PubUpdater {}
 
 class _MockProcessSignal extends Mock implements ProcessSignal {}
 
+class _MockStdin extends Mock implements Stdin {}
+
 const expectedUsage = [
   'A fast, minimalistic backend framework for Dart.\n'
       '\n'
@@ -78,11 +80,14 @@ void main() {
         pubUpdater: pubUpdater,
         exit: (_) {},
         sigint: sigint,
+        stdin: _MockStdin(),
       );
     });
 
     test('can be instantiated without any explicit parameters', () {
-      final commandRunner = DartFrogCommandRunner();
+      final commandRunner = DartFrogCommandRunner(
+        stdin: stdin,
+      );
       expect(commandRunner, isNotNull);
     });
 
@@ -114,6 +119,7 @@ void main() {
           pubUpdater: pubUpdater,
           exit: exitCalls.add,
           sigint: sigint,
+          stdin: _MockStdin(),
         );
         when(() => sigint.watch()).thenAnswer((_) => Stream.value(sigint));
         await commandRunner.run(['--version']);

--- a/packages/dart_frog_cli/test/src/command_runner_test.dart
+++ b/packages/dart_frog_cli/test/src/command_runner_test.dart
@@ -85,9 +85,7 @@ void main() {
     });
 
     test('can be instantiated without any explicit parameters', () {
-      final commandRunner = DartFrogCommandRunner(
-        stdin: stdin,
-      );
+      final commandRunner = DartFrogCommandRunner();
       expect(commandRunner, isNotNull);
     });
 

--- a/packages/dart_frog_cli/test/src/commands/daemon/daemon_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/daemon/daemon_test.dart
@@ -19,6 +19,8 @@ class _MockLogger extends Mock implements Logger {}
 
 class _MockProcessSignal extends Mock implements ProcessSignal {}
 
+class _MockStdin extends Mock implements Stdin {}
+
 const expectedUsage = [
   // ignore: no_adjacent_strings_in_list
   'Start the Dart Frog daemon\n'
@@ -44,6 +46,7 @@ void main() {
         pubUpdater: _MockPubUpdater(),
         exit: (_) {},
         sigint: sigint,
+        stdin: _MockStdin(),
       );
     });
 

--- a/packages/dart_frog_cli/test/src/commands/dev/dev_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/dev/dev_test.dart
@@ -62,8 +62,9 @@ void main() {
           return runner;
         },
         logger: logger,
-        stdin: stdin,
-      )..testArgResults = argResults;
+      )
+        ..testArgResults = argResults
+        ..testStdin = stdin;
 
       expect(
         command.run(),
@@ -107,8 +108,8 @@ void main() {
           return runner;
         },
         logger: logger,
-        stdin: stdin,
       )
+        ..testStdin = stdin
         ..testArgResults = argResults
         ..testCwd = cwd;
 
@@ -138,8 +139,14 @@ void main() {
           return runner;
         },
         logger: logger,
-        stdin: stdin,
-      )..testArgResults = argResults;
+      )
+        ..testArgResults = argResults
+        ..testStdin = stdin;
+
+      when(() => runner.start()).thenAnswer((_) => Future.value());
+      when(() => runner.exitCode).thenAnswer(
+        (_) => Future.value(ExitCode.success),
+      );
 
       when(() => runner.start()).thenAnswer((_) => Future.value());
       when(() => runner.exitCode).thenAnswer((_) async => ExitCode.unavailable);
@@ -162,8 +169,9 @@ void main() {
           return runner;
         },
         logger: logger,
-        stdin: stdin,
-      )..testArgResults = argResults;
+      )
+        ..testArgResults = argResults
+        ..testStdin = stdin;
 
       when(() => runner.start()).thenAnswer((_) async {
         throw DartFrogDevServerException('oops');
@@ -229,8 +237,9 @@ void main() {
             return runner;
           },
           logger: logger,
-          stdin: stdin,
-        )..testArgResults = argResults;
+        )
+          ..testArgResults = argResults
+          ..testStdin = stdin;
       });
 
       test('listens for R on hot reload enabled', () async {

--- a/packages/dart_frog_cli/test/src/commands/list/list_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/list/list_test.dart
@@ -28,6 +28,8 @@ class _FakeDirectoryGeneratorTarget extends Fake
 
 class _MockRouteConfiguration extends Mock implements RouteConfiguration {}
 
+class _MockStdin extends Mock implements Stdin {}
+
 const expectedUsage = [
   'Lists the routes on a Dart Frog project.\n'
       '\n'
@@ -76,6 +78,7 @@ void main() {
         pubUpdater: _MockPubUpdater(),
         exit: (_) {},
         sigint: sigint,
+        stdin: _MockStdin(),
       );
     });
 

--- a/packages/dart_frog_cli/test/src/commands/new/new_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/new/new_test.dart
@@ -29,6 +29,8 @@ class _MockProgress extends Mock implements Progress {}
 class _FakeDirectoryGeneratorTarget extends Fake
     implements DirectoryGeneratorTarget {}
 
+class _MockStdin extends Mock implements Stdin {}
+
 const expectedUsage = [
   'Create a new route or middleware for dart_frog\n'
       '\n'
@@ -79,6 +81,7 @@ void main() {
         pubUpdater: _MockPubUpdater(),
         exit: (_) {},
         sigint: sigint,
+        stdin: _MockStdin(),
       );
     });
 

--- a/packages/dart_frog_cli/test/src/commands/update/update_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/update/update_test.dart
@@ -23,6 +23,8 @@ class _MockArgResults extends Mock implements ArgResults {}
 
 class _MockProcessSignal extends Mock implements ProcessSignal {}
 
+class _MockStdin extends Mock implements Stdin {}
+
 const expectedUsage = [
   'Update the Dart Frog CLI.\n'
       '\n'
@@ -76,6 +78,7 @@ void main() {
         pubUpdater: _MockPubUpdater(),
         exit: (_) {},
         sigint: sigint,
+        stdin: _MockStdin(),
       );
     });
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

test(dart_frog_cli): mock stdin in the ommand run level


For some reason, using io's std directly on gh action causes the build to fail on random places. For example here:


<img width="903" alt="Screenshot 2023-08-04 at 14 36 06" src="https://github.com/VeryGoodOpenSource/dart_frog/assets/6718144/7ee9d5e5-9bcc-4598-aa45-310ac50fb66b">?


This pr ensures stdin is always mocked

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
