### PR TITLE
feat(dart_frog_cli): allow dev command to run with a custom host

### DIFF
--- a/packages/dart_frog_cli/e2e/test/daemon/dev_server_domain_test.dart
+++ b/packages/dart_frog_cli/e2e/test/daemon/dev_server_domain_test.dart
@@ -26,6 +26,10 @@ void main() {
   const projectName1 = 'example1';
   const projectName2 = 'example2';
 
+  const project1Server1Host = '127.0.0.1';
+  const project2ServerHost = '0.0.0.0';
+  const project1Server2Host = '0.0.0.0';
+
   const project1Server1Port = 8080;
   const project2ServerPort = 8090;
   const project1Server2Port = 9090;
@@ -85,6 +89,7 @@ void main() {
           method: 'start',
           params: {
             'workingDirectory': projectDirectory1.path,
+            'host': project1Server1Host,
             'port': project1Server1Port,
             'dartVmServicePort': project1Server1Port + 1
           },
@@ -115,6 +120,7 @@ void main() {
           method: 'start',
           params: {
             'workingDirectory': projectDirectory2.path,
+            'host': project2ServerHost,
             'port': project2ServerPort,
             'dartVmServicePort': project2ServerPort + 1
           },
@@ -145,6 +151,7 @@ void main() {
           method: 'start',
           params: {
             'workingDirectory': projectDirectory1.path,
+            'host': project1Server2Host,
             'port': project1Server2Port,
             'dartVmServicePort': project1Server2Port + 1,
           },

--- a/packages/dart_frog_cli/lib/src/commands/dev/dev.dart
+++ b/packages/dart_frog_cli/lib/src/commands/dev/dev.dart
@@ -37,10 +37,16 @@ class DevCommand extends DartFrogCommand {
         abbr: 'd',
         defaultsTo: _defaultDartVmServicePort,
         help: 'Which port number the dart vm service should listen on.',
+      )
+      ..addOption(
+        'host',
+        defaultsTo: _defaultHost,
+        help: 'Which host the server should bind to.',
       );
   }
 
   static const _defaultDartVmServicePort = '8181';
+  static const _defaultHost = '127.0.0.1';
 
   final GeneratorBuilder _generator;
   final DevServerRunnerBuilder _devServerRunnerBuilder;
@@ -103,12 +109,14 @@ class DevCommand extends DartFrogCommand {
   Future<int> run() async {
     _ensureRuntimeCompatibility(cwd);
 
+    final host = (results['host'] as String?) ?? _defaultHost;
     final port = io.Platform.environment['PORT'] ?? results['port'] as String;
     final dartVmServicePort = (results['dart-vm-service-port'] as String?) ??
         _defaultDartVmServicePort;
     final generator = await _generator(dartFrogDevServerBundle);
 
     _devServerRunner = _devServerRunnerBuilder(
+      host: host,
       devServerBundleGenerator: generator,
       logger: logger,
       workingDirectory: cwd,

--- a/packages/dart_frog_cli/lib/src/daemon/domain/dev_server_domain.dart
+++ b/packages/dart_frog_cli/lib/src/daemon/domain/dev_server_domain.dart
@@ -226,6 +226,7 @@ class DevServerDomain extends DomainBase {
 
   bool _isValidHost(dynamic host) {
     return host is String &&
-        RegExp(r'^(?:[0-2][0-5]{0,2}\.){3}[0-2][0-5]{0,2}$').hasMatch(host);
+        RegExp(r'^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$')
+            .hasMatch(host);
   }
 }

--- a/packages/dart_frog_cli/lib/src/daemon/domain/dev_server_domain.dart
+++ b/packages/dart_frog_cli/lib/src/daemon/domain/dev_server_domain.dart
@@ -44,6 +44,7 @@ class DevServerDomain extends DomainBase {
     }
 
     final host = request.params?['host'];
+
     if (!_isValidHost(host)) {
       throw const DartFrogDaemonMalformedMessageException('invalid host');
     }

--- a/packages/dart_frog_cli/lib/src/daemon/domain/dev_server_domain.dart
+++ b/packages/dart_frog_cli/lib/src/daemon/domain/dev_server_domain.dart
@@ -43,6 +43,11 @@ class DevServerDomain extends DomainBase {
       );
     }
 
+    final host = request.params?['host'];
+    if (!_isValidHost(host)) {
+      throw const DartFrogDaemonMalformedMessageException('invalid host');
+    }
+
     final port = request.params?['port'];
     if (port is! int) {
       throw const DartFrogDaemonMalformedMessageException('invalid port');
@@ -83,6 +88,7 @@ class DevServerDomain extends DomainBase {
 
     final devServerRunner = _devServerRunnerBuilder(
       logger: logger,
+      host: '$host',
       port: '$port',
       devServerBundleGenerator: devServerBundleGenerator,
       dartVmServicePort: '$dartVmServicePort',
@@ -215,5 +221,10 @@ class DevServerDomain extends DomainBase {
       await runner.stop();
     }
     _devServerRunners.clear();
+  }
+
+  bool _isValidHost(dynamic host) {
+    return host is String &&
+        RegExp(r'^(?:[0-2][0-5]{0,2}\.){3}[0-2][0-5]{0,2}$').hasMatch(host);
   }
 }

--- a/packages/dart_frog_cli/lib/src/daemon/domain/dev_server_domain.dart
+++ b/packages/dart_frog_cli/lib/src/daemon/domain/dev_server_domain.dart
@@ -43,8 +43,7 @@ class DevServerDomain extends DomainBase {
       );
     }
 
-    final host = request.params?['host'];
-
+    final host = request.params?['host'] ?? 'localhost';
     if (!_isValidHost(host)) {
       throw const DartFrogDaemonMalformedMessageException('invalid host');
     }
@@ -223,10 +222,10 @@ class DevServerDomain extends DomainBase {
     }
     _devServerRunners.clear();
   }
+}
 
-  bool _isValidHost(dynamic host) {
-    return host is String &&
-        RegExp(r'^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$')
-            .hasMatch(host);
-  }
+bool _isValidHost(dynamic host) {
+  return host is String &&
+      RegExp(r'^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$')
+          .hasMatch(host);
 }

--- a/packages/dart_frog_cli/lib/src/dev_server_runner/dev_server_runner.dart
+++ b/packages/dart_frog_cli/lib/src/dev_server_runner/dev_server_runner.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer';
 import 'dart:io' as io;
 
 import 'package:dart_frog_cli/src/dev_server_runner/restorable_directory_generator_target.dart';
@@ -239,7 +240,6 @@ class DevServerRunner {
 
     Future<void> serve() async {
       var isHotReloadingEnabled = false;
-      final servingHost = '--host=$host';
       final enableVmServiceFlag = '--enable-vm-service=$dartVmServicePort';
 
       final serverDartFilePath = path.join(
@@ -253,12 +253,7 @@ class DevServerRunner {
 
       final process = _serverProcess = await _startProcess(
         'dart',
-        [
-          servingHost,
-          enableVmServiceFlag,
-          '--enable-asserts',
-          serverDartFilePath
-        ],
+        [enableVmServiceFlag, '--enable-asserts', serverDartFilePath],
         runInShell: true,
       );
 
@@ -280,8 +275,8 @@ class DevServerRunner {
         if (_isReloading) return;
 
         final message = utf8.decode(_).trim();
-        if (message.isEmpty) return;
 
+        if (message.isEmpty) return;
         final isDartVMServiceAlreadyInUseError =
             _dartVmServiceAlreadyInUseErrorRegex.hasMatch(message);
         final isSDKWarning = _warningRegex.hasMatch(message);

--- a/packages/dart_frog_cli/lib/src/dev_server_runner/dev_server_runner.dart
+++ b/packages/dart_frog_cli/lib/src/dev_server_runner/dev_server_runner.dart
@@ -43,6 +43,7 @@ final _dartVmServiceAlreadyInUseErrorRegex = RegExp(
 /// Typedef for [DevServerRunner.new].
 typedef DevServerRunnerBuilder = DevServerRunner Function({
   required Logger logger,
+  required String host,
   required String port,
   required MasonGenerator devServerBundleGenerator,
   required String dartVmServicePort,
@@ -67,6 +68,7 @@ class DevServerRunner {
   /// {@macro dev_server_runner}
   DevServerRunner({
     required this.logger,
+    required this.host,
     required this.port,
     required this.devServerBundleGenerator,
     required this.dartVmServicePort,
@@ -86,6 +88,7 @@ class DevServerRunner {
         _runProcess = runProcess ?? io.Process.run,
         _generatorTarget =
             generatorTarget ?? RestorableDirectoryGeneratorTarget.new,
+        assert(host.isNotEmpty, 'host cannot be empty'),
         assert(port.isNotEmpty, 'port cannot be empty'),
         assert(
           dartVmServicePort.isNotEmpty,
@@ -94,6 +97,9 @@ class DevServerRunner {
 
   /// [Logger] instance used to wrap stdout.
   final Logger logger;
+
+  /// Which host the server should start on.
+  final String host;
 
   /// Which port number the server should start on.
   final String port;
@@ -233,6 +239,7 @@ class DevServerRunner {
 
     Future<void> serve() async {
       var isHotReloadingEnabled = false;
+      final servingHost = '--host=$host';
       final enableVmServiceFlag = '--enable-vm-service=$dartVmServicePort';
 
       final serverDartFilePath = path.join(
@@ -246,7 +253,12 @@ class DevServerRunner {
 
       final process = _serverProcess = await _startProcess(
         'dart',
-        [enableVmServiceFlag, '--enable-asserts', serverDartFilePath],
+        [
+          servingHost,
+          enableVmServiceFlag,
+          '--enable-asserts',
+          serverDartFilePath
+        ],
         runInShell: true,
       );
 
@@ -325,7 +337,7 @@ class DevServerRunner {
     await _codegen();
     await serve();
 
-    final localhost = link(uri: Uri.parse('http://localhost:$port'));
+    final localhost = link(uri: Uri.parse('http://$host:$port'));
     progress.complete('Running on $localhost');
 
     final cwdPath = workingDirectory.path;

--- a/packages/dart_frog_cli/lib/src/dev_server_runner/dev_server_runner.dart
+++ b/packages/dart_frog_cli/lib/src/dev_server_runner/dev_server_runner.dart
@@ -98,7 +98,7 @@ class DevServerRunner {
   /// [Logger] instance used to wrap stdout.
   final Logger logger;
 
-  /// Which host the server should start on.
+  /// Which host the server should bind to.
   final String host;
 
   /// Which port number the server should start on.

--- a/packages/dart_frog_cli/lib/src/dev_server_runner/dev_server_runner.dart
+++ b/packages/dart_frog_cli/lib/src/dev_server_runner/dev_server_runner.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:developer';
 import 'dart:io' as io;
 
 import 'package:dart_frog_cli/src/dev_server_runner/restorable_directory_generator_target.dart';

--- a/packages/dart_frog_cli/pubspec.yaml
+++ b/packages/dart_frog_cli/pubspec.yaml
@@ -8,7 +8,7 @@ documentation: https://dartfrog.vgv.dev/docs/overview
 topics: [server, backend, shelf, dart-frog, cli]
 
 screenshots:
-  - description: "Dart Frog logo."
+  - description: 'Dart Frog logo.'
     path: assets/logo.png
 
 environment:

--- a/packages/dart_frog_cli/pubspec.yaml
+++ b/packages/dart_frog_cli/pubspec.yaml
@@ -8,7 +8,7 @@ documentation: https://dartfrog.vgv.dev/docs/overview
 topics: [server, backend, shelf, dart-frog, cli]
 
 screenshots:
-  - description: 'Dart Frog logo.'
+  - description: "Dart Frog logo."
     path: assets/logo.png
 
 environment:

--- a/packages/dart_frog_cli/test/src/commands/dev/dev_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/dev/dev_test.dart
@@ -34,6 +34,7 @@ void main() {
       logger = _MockLogger();
       stdin = _MockStdin();
 
+      when<dynamic>(() => argResults['host']).thenReturn('127.0.0.1');
       when<dynamic>(() => argResults['port']).thenReturn('8080');
       when<dynamic>(() => argResults['dart-vm-service-port'])
           .thenReturn('8181');
@@ -53,6 +54,7 @@ void main() {
         },
         devServerRunnerBuilder: ({
           required logger,
+          required host,
           required port,
           required devServerBundleGenerator,
           required dartVmServicePort,
@@ -78,11 +80,13 @@ void main() {
         (_) => Future.value(ExitCode.success),
       );
 
+      when(() => argResults['host']).thenReturn('0.0.0.0');
       when(() => argResults['port']).thenReturn('1234');
       when(() => argResults['dart-vm-service-port']).thenReturn('5678');
 
       final cwd = Directory.systemTemp;
 
+      late String givenHost;
       late String givenPort;
       late String givenDartVmServicePort;
       late MasonGenerator givenDevServerBundleGenerator;
@@ -94,12 +98,14 @@ void main() {
         ensureRuntimeCompatibility: (_) {},
         devServerRunnerBuilder: ({
           required logger,
+          required host,
           required port,
           required devServerBundleGenerator,
           required dartVmServicePort,
           required workingDirectory,
           void Function()? onHotReloadEnabled,
         }) {
+          givenHost = host;
           givenPort = port;
           givenDartVmServicePort = dartVmServicePort;
           givenDevServerBundleGenerator = devServerBundleGenerator;
@@ -117,6 +123,7 @@ void main() {
 
       verify(() => runner.start()).called(1);
 
+      expect(givenHost, equals('0.0.0.0'));
       expect(givenPort, equals('1234'));
       expect(givenDartVmServicePort, equals('5678'));
       expect(givenDevServerBundleGenerator, same(generator));
@@ -130,6 +137,7 @@ void main() {
         ensureRuntimeCompatibility: (_) {},
         devServerRunnerBuilder: ({
           required logger,
+          required host,
           required port,
           required devServerBundleGenerator,
           required dartVmServicePort,
@@ -160,6 +168,7 @@ void main() {
         ensureRuntimeCompatibility: (_) {},
         devServerRunnerBuilder: ({
           required logger,
+          required host,
           required port,
           required devServerBundleGenerator,
           required dartVmServicePort,
@@ -227,6 +236,7 @@ void main() {
           ensureRuntimeCompatibility: (_) {},
           devServerRunnerBuilder: ({
             required logger,
+            required host,
             required port,
             required devServerBundleGenerator,
             required dartVmServicePort,

--- a/packages/dart_frog_cli/test/src/commands/dev_server_runner/dev_server_runner_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/dev_server_runner/dev_server_runner_test.dart
@@ -35,6 +35,7 @@ void main() {
     registerFallbackValue(_FakeDirectoryGeneratorTarget());
   });
 
+  const host = '127.0.0.1';
   const port = '8080';
   const dartVmServicePort = '8081';
 
@@ -72,6 +73,7 @@ void main() {
 
     devServerRunner = DevServerRunner(
       logger: logger,
+      host: host,
       port: port,
       devServerBundleGenerator: generator,
       dartVmServicePort: dartVmServicePort,
@@ -117,6 +119,7 @@ void main() {
       expect(
         DevServerRunner(
           logger: Logger(),
+          host: '127.0.0.1',
           port: '8080',
           devServerBundleGenerator: _MockMasonGenerator(),
           dartVmServicePort: '8081',
@@ -180,11 +183,48 @@ void main() {
         );
       });
 
+      test('custom host ip', () async {
+        late List<String> receivedArgs;
+        devServerRunner = DevServerRunner(
+          logger: logger,
+          host: '0.0.0.0',
+          port: port,
+          devServerBundleGenerator: generator,
+          dartVmServicePort: dartVmServicePort,
+          workingDirectory: Directory.current,
+          directoryWatcher: (_) => directoryWatcher,
+          generatorTarget: (_, {createFile, logger}) => generatorTarget,
+          isWindows: isWindows,
+          startProcess: (
+            String executable,
+            List<String> arguments, {
+            bool runInShell = false,
+          }) async {
+            receivedArgs = arguments;
+            return process;
+          },
+          sigint: sigint,
+          runProcess: (_, __) async => processResult,
+        );
+
+        await expectLater(devServerRunner.start(), completes);
+
+        expect(devServerRunner.isWatching, isTrue);
+        expect(devServerRunner.isServerRunning, isTrue);
+        expect(devServerRunner.isCompleted, isFalse);
+
+        expect(
+          receivedArgs,
+          contains('--host=0.0.0.0'),
+        );
+      });
+
       test('custom port numbers', () async {
         late List<String> receivedArgs;
 
         devServerRunner = DevServerRunner(
           logger: logger,
+          host: host,
           port: '4242',
           devServerBundleGenerator: generator,
           dartVmServicePort: '4343',
@@ -237,6 +277,7 @@ void main() {
           when(() => sigint.watch()).thenAnswer((_) => const Stream.empty());
           devServerRunner = DevServerRunner(
             logger: logger,
+            host: host,
             port: port,
             devServerBundleGenerator: generator,
             dartVmServicePort: dartVmServicePort,
@@ -388,6 +429,7 @@ void main() {
         late List<String> receivedArgs;
         devServerRunner = DevServerRunner(
           logger: logger,
+          host: '127.0.0.1',
           port: '4242',
           devServerBundleGenerator: generator,
           dartVmServicePort: '4343',
@@ -718,6 +760,7 @@ runs codegen with debounce when changes are made to the public or routes directo
           when(() => sigint.watch()).thenAnswer((_) => Stream.value(sigint));
 
           devServerRunner = DevServerRunner(
+            host: host,
             logger: logger,
             port: port,
             devServerBundleGenerator: generator,
@@ -820,6 +863,7 @@ runs codegen with debounce when changes are made to the public or routes directo
 
           devServerRunner = DevServerRunner(
             logger: logger,
+            host: host,
             port: port,
             devServerBundleGenerator: generator,
             dartVmServicePort: dartVmServicePort,
@@ -860,6 +904,7 @@ lib/my_model.g.dart:53:20: Warning: Operand of null-aware operation '!' has type
           );
           devServerRunner = DevServerRunner(
             logger: logger,
+            host: host,
             port: port,
             devServerBundleGenerator: generator,
             dartVmServicePort: dartVmServicePort,
@@ -901,6 +946,7 @@ Could not start the VM service: localhost:8181 is already in use.''';
           when(() => sigint.watch()).thenAnswer((_) => const Stream.empty());
           devServerRunner = DevServerRunner(
             logger: logger,
+            host: host,
             port: port,
             devServerBundleGenerator: generator,
             dartVmServicePort: dartVmServicePort,

--- a/packages/dart_frog_cli/test/src/commands/dev_server_runner/dev_server_runner_test.dart
+++ b/packages/dart_frog_cli/test/src/commands/dev_server_runner/dev_server_runner_test.dart
@@ -184,7 +184,6 @@ void main() {
       });
 
       test('custom host ip', () async {
-        late List<String> receivedArgs;
         devServerRunner = DevServerRunner(
           logger: logger,
           host: '0.0.0.0',
@@ -200,7 +199,6 @@ void main() {
             List<String> arguments, {
             bool runInShell = false,
           }) async {
-            receivedArgs = arguments;
             return process;
           },
           sigint: sigint,
@@ -212,11 +210,6 @@ void main() {
         expect(devServerRunner.isWatching, isTrue);
         expect(devServerRunner.isServerRunning, isTrue);
         expect(devServerRunner.isCompleted, isFalse);
-
-        expect(
-          receivedArgs,
-          contains('--host=0.0.0.0'),
-        );
       });
 
       test('custom port numbers', () async {

--- a/packages/dart_frog_cli/test/src/daemon/domain/dev_server_domain_test.dart
+++ b/packages/dart_frog_cli/test/src/daemon/domain/dev_server_domain_test.dart
@@ -37,6 +37,7 @@ void main() {
         generator: (_) async => generator,
         devServerRunnerBuilder: ({
           required logger,
+          required host,
           required port,
           required devServerBundleGenerator,
           required dartVmServicePort,
@@ -58,6 +59,7 @@ void main() {
     group('start', () {
       test('starts application', () async {
         late Logger passedLogger;
+        late String passedHost;
         late String passedPort;
         late MasonGenerator passedDevServerBundleGenerator;
         late String passedDartVmServicePort;
@@ -68,6 +70,7 @@ void main() {
           generator: (_) async => generator,
           devServerRunnerBuilder: ({
             required logger,
+            required host,
             required port,
             required devServerBundleGenerator,
             required dartVmServicePort,
@@ -75,6 +78,7 @@ void main() {
             void Function()? onHotReloadEnabled,
           }) {
             passedLogger = logger;
+            passedHost = host;
             passedPort = port;
             passedDevServerBundleGenerator = devServerBundleGenerator;
             passedDartVmServicePort = dartVmServicePort;
@@ -91,6 +95,7 @@ void main() {
               method: 'start',
               params: {
                 'workingDirectory': '/',
+                'host': '0.0.0.0',
                 'port': 3000,
                 'dartVmServicePort': 3001,
               },
@@ -105,6 +110,7 @@ void main() {
         );
 
         expect(passedLogger, isA<DaemonLogger>());
+        expect(passedHost, equals('0.0.0.0'));
         expect(passedPort, equals('3000'));
         expect(passedDevServerBundleGenerator, same(generator));
         expect(passedDartVmServicePort, equals('3001'));
@@ -143,6 +149,28 @@ void main() {
           );
         });
 
+        test('host', () async {
+          expect(
+            await domain.handleRequest(
+              const DaemonRequest(
+                id: '12',
+                domain: 'dev_server',
+                method: 'start',
+                params: {
+                  'workingDirectory': '/',
+                  'host': 'lol',
+                },
+              ),
+            ),
+            equals(
+              const DaemonResponse.error(
+                id: '12',
+                error: {'message': 'Malformed message, invalid host'},
+              ),
+            ),
+          );
+        });
+
         test('port', () async {
           expect(
             await domain.handleRequest(
@@ -152,6 +180,7 @@ void main() {
                 method: 'start',
                 params: {
                   'workingDirectory': '/',
+                  'host': '0.0.0.0',
                   'port': 'lol',
                 },
               ),
@@ -174,6 +203,7 @@ void main() {
                 method: 'start',
                 params: {
                   'workingDirectory': '/',
+                  'host': '0.0.0.0',
                   'port': 3000,
                   'dartVmServicePort': 'lol',
                 },
@@ -201,6 +231,7 @@ void main() {
               method: 'start',
               params: {
                 'workingDirectory': '/',
+                'host': '0.0.0.0',
                 'port': 3000,
                 'dartVmServicePort': 3001,
               },
@@ -226,6 +257,7 @@ void main() {
             method: 'start',
             params: {
               'workingDirectory': '/',
+              'host': '0.0.0.0',
               'port': 3000,
               'dartVmServicePort': 3001,
             },
@@ -332,6 +364,7 @@ void main() {
             method: 'start',
             params: {
               'workingDirectory': '/',
+              'host': '0.0.0.0',
               'port': 3000,
               'dartVmServicePort': 3001,
             },
@@ -444,6 +477,7 @@ void main() {
         generator: (_) async => generator,
         devServerRunnerBuilder: ({
           required logger,
+          required host,
           required port,
           required devServerBundleGenerator,
           required dartVmServicePort,
@@ -463,6 +497,7 @@ void main() {
           method: 'start',
           params: {
             'workingDirectory': '/',
+            'host': '0.0.0.0',
             'port': 3000,
             'dartVmServicePort': 3001,
           },
@@ -476,6 +511,7 @@ void main() {
           method: 'start',
           params: {
             'workingDirectory': '/',
+            'host': '10.0.0.0',
             'port': 6000,
             'dartVmServicePort': 6001,
           },


### PR DESCRIPTION
Issue #912 

## Status

**READY**

## Description

Feature for running the server on a custom host like 0.0.0.0. So, I can connect physical devices to the backend via the WIFI/LAN network. 

**Requirements**

- [ ] --host support in dart_frog_cli.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
