### PR TITLE
feat(vscode): allow attaching development server to Dart debugger

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -65,6 +65,10 @@
       {
         "command": "dart-frog.stop-dev-server",
         "title": "Dart Frog: Stop Development Server"
+      },
+      {
+        "command": "dart-frog.debug-dev-server",
+        "title": "Dart Frog: Debug Development Server"
       }
     ],
     "menus": {

--- a/extensions/vscode/src/commands/debug-dev-server.ts
+++ b/extensions/vscode/src/commands/debug-dev-server.ts
@@ -41,11 +41,9 @@ export const debugDevServer = async (): Promise<void> => {
     await window.withProgress(
       {
         location: 15,
-        title: `Activating Dart extension...`,
+        title: "Activating Dart extension...",
       },
-      async () => {
-        await dartExtension.activate();
-      }
+      dartExtension.activate
     );
   }
 
@@ -86,7 +84,7 @@ export const debugDevServer = async (): Promise<void> => {
     debugSession.configuration.applicationId === application.id
   ) {
     const selection = await window.showInformationMessage(
-      `A debug session is already running for this application.`,
+      "A debug session is already running for this application.",
       "Create another debug session",
       "Cancel"
     );
@@ -113,7 +111,7 @@ async function attachToDebugSession(
   await window.withProgress(
     {
       location: 15,
-      title: `Attaching to debug session...`,
+      title: "Attaching to debug session...",
     },
     async function () {
       return await debug.startDebugging(undefined, {

--- a/extensions/vscode/src/commands/debug-dev-server.ts
+++ b/extensions/vscode/src/commands/debug-dev-server.ts
@@ -46,7 +46,7 @@ export const debugDevServer = async (): Promise<void> => {
         location: 15,
         title: `Activating Dart extension...`,
       },
-      async function () {
+      async () => {
         await dartExtension.activate();
       }
     );

--- a/extensions/vscode/src/commands/debug-dev-server.ts
+++ b/extensions/vscode/src/commands/debug-dev-server.ts
@@ -1,0 +1,5 @@
+import { window } from "vscode";
+
+export const debugDevServer = async (): Promise<void> => {
+  window.showInformationMessage("Debugging dev server...");
+};

--- a/extensions/vscode/src/commands/debug-dev-server.ts
+++ b/extensions/vscode/src/commands/debug-dev-server.ts
@@ -29,13 +29,14 @@ export const debugDevServer = async (): Promise<void> => {
           Uri.parse(dartCodeMarketplaceUri)
         );
         return;
+      case "Cancel":
       default:
         return;
     }
   }
 
   if (!dartExtension.isActive) {
-    window.withProgress(
+    await window.withProgress(
       {
         location: 15,
         title: `Activating Dart extension...`,
@@ -96,7 +97,7 @@ export const debugDevServer = async (): Promise<void> => {
     }
   }
 
-  attachToDebugSession(application);
+  await attachToDebugSession(application);
 };
 
 /**

--- a/extensions/vscode/src/commands/debug-dev-server.ts
+++ b/extensions/vscode/src/commands/debug-dev-server.ts
@@ -24,7 +24,7 @@ export const debugDevServer = async (): Promise<void> => {
       case "Install Dart extension":
         const dartCodeMarketplaceUri =
           "https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code";
-        await commands.executeCommand(
+        commands.executeCommand(
           "vscode.open",
           Uri.parse(dartCodeMarketplaceUri)
         );
@@ -33,7 +33,9 @@ export const debugDevServer = async (): Promise<void> => {
       default:
         return;
     }
+    /* c8 ignore start */
   }
+  /* c8 ignore stop */
 
   if (!dartExtension.isActive) {
     await window.withProgress(

--- a/extensions/vscode/src/commands/debug-dev-server.ts
+++ b/extensions/vscode/src/commands/debug-dev-server.ts
@@ -1,5 +1,158 @@
-import { window } from "vscode";
+import {
+  ProgressOptions,
+  QuickInputButton,
+  QuickPickItem,
+  QuickPickItemKind,
+  Uri,
+  commands,
+  debug,
+  extensions,
+  window,
+} from "vscode";
+import { isDartFrogCLIInstalled, suggestInstallingDartFrogCLI } from "../utils";
+import { DartFrogApplication, DartFrogDaemon } from "../daemon";
 
 export const debugDevServer = async (): Promise<void> => {
-  window.showInformationMessage("Debugging dev server...");
+  if (!isDartFrogCLIInstalled()) {
+    await suggestInstallingDartFrogCLI(
+      "Running this command requires Dart Frog CLI to be installed."
+    );
+  }
+
+  const dartExtension = extensions.getExtension("Dart-Code.dart-code");
+  if (!dartExtension) {
+    const selection = await window.showErrorMessage(
+      "Running this command requires the Dart extension.",
+      "Install Dart extension",
+      "Cancel"
+    );
+    switch (selection) {
+      case "Install Dart extension":
+        const dartCodeMarketplaceUri =
+          "https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code";
+        await commands.executeCommand(
+          "vscode.open",
+          Uri.parse(dartCodeMarketplaceUri)
+        );
+        return;
+      default:
+        return;
+    }
+  }
+
+  if (!dartExtension.isActive) {
+    window.withProgress(
+      {
+        location: 15,
+        title: `Activating Dart extension...`,
+      },
+      async function () {
+        await dartExtension.activate();
+      }
+    );
+  }
+
+  const daemon = DartFrogDaemon.instance;
+  const applications = daemon.applicationRegistry.all();
+  if (!daemon.isReady || applications.length === 0) {
+    const selection = await window.showInformationMessage(
+      "No running servers found.",
+      "Start server",
+      "Cancel"
+    );
+    switch (selection) {
+      case "Start server":
+        commands.executeCommand("dart-frog.start-dev-server");
+        return;
+      case "Cancel":
+      default:
+        return;
+    }
+  }
+
+  const application =
+    applications.length === 1
+      ? applications[0]
+      : await quickPickApplication(applications);
+  if (!application) {
+    return;
+  }
+
+  // TODO(alestiago): Check running debug session to avoid duplicate
+  // debug sessions.
+  attachToDebugSession(application);
 };
+
+// TODO(alestiago): Move this to a separate file to be shared with
+// src/commands/stop-dev-server.ts.
+class PickableDartFrogApplication implements QuickPickItem {
+  constructor(dartFrogApplication: DartFrogApplication) {
+    const addressWithoutProtocol = dartFrogApplication.address!.replace(
+      /.*?:\/\//g,
+      ""
+    );
+    this.label = `$(globe) ${addressWithoutProtocol}`;
+    this.description = dartFrogApplication.id!.toString();
+    this.application = dartFrogApplication;
+  }
+
+  public readonly application: DartFrogApplication;
+
+  label: string;
+  kind?: QuickPickItemKind | undefined;
+  description?: string | undefined;
+  detail?: string | undefined;
+  picked?: boolean | undefined;
+  alwaysShow?: boolean | undefined;
+  buttons?: readonly QuickInputButton[] | undefined;
+}
+
+// TODO(alestiago): Move this to a separate file to be shared with
+// src/commands/stop-dev-server.ts.
+/**
+ * Prompts the user to select a {@link DartFrogApplication} from a list of
+ * running {@link DartFrogApplication}s.
+ *
+ * @param applications The running {@link DartFrogApplication}s to choose from.
+ * @returns The selected {@link DartFrogApplication} or `undefined` if the user
+ * cancelled the selection.
+ */
+async function quickPickApplication(
+  applications: DartFrogApplication[]
+): Promise<DartFrogApplication | undefined> {
+  const quickPick = window.createQuickPick<PickableDartFrogApplication>();
+  quickPick.placeholder = "Select a server to stop";
+  quickPick.busy = true;
+  quickPick.ignoreFocusOut = true;
+  quickPick.items = applications.map(
+    (application) => new PickableDartFrogApplication(application)
+  );
+  quickPick.show();
+
+  return new Promise<DartFrogApplication | undefined>((resolve) => {
+    quickPick.onDidChangeSelection((value) => {
+      quickPick.dispose();
+
+      if (!value || value.length === 0) {
+        resolve(undefined);
+      } else {
+        resolve(value[0]!.application);
+      }
+    });
+  });
+}
+
+function attachToDebugSession(application: DartFrogApplication): void {
+  const options: ProgressOptions = {
+    location: 15,
+    title: `Attaching to debug session...`,
+  };
+  window.withProgress(options, async function () {
+    return await debug.startDebugging(undefined, {
+      name: `Dart Frog: Development Server (${application.port})`,
+      request: "attach",
+      type: "dart",
+      vmServiceUri: application.vmServiceUri,
+    });
+  });
+}

--- a/extensions/vscode/src/commands/index.ts
+++ b/extensions/vscode/src/commands/index.ts
@@ -6,3 +6,4 @@ export * from "./new-middleware";
 export * from "./start-daemon";
 export * from "./start-dev-server";
 export * from "./stop-dev-server";
+export * from "./debug-dev-server";

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -8,6 +8,7 @@ import {
   startDaemon,
   startDevServer,
   stopDevServer,
+  debugDevServer,
 } from "./commands";
 import {
   readDartFrogCLIVersion,
@@ -50,7 +51,11 @@ export function activate(
       "dart-frog.start-dev-server",
       startDevServer
     ),
-    vscode.commands.registerCommand("dart-frog.stop-dev-server", stopDevServer)
+    vscode.commands.registerCommand("dart-frog.stop-dev-server", stopDevServer),
+    vscode.commands.registerCommand(
+      "dart-frog.debug-dev-server",
+      debugDevServer
+    )
   );
   return context;
 }

--- a/extensions/vscode/src/test/suite/commands/debug-dev-server.test.ts
+++ b/extensions/vscode/src/test/suite/commands/debug-dev-server.test.ts
@@ -1,0 +1,537 @@
+const sinon = require("sinon");
+var proxyquire = require("proxyquire");
+
+import { afterEach, beforeEach } from "mocha";
+import {
+  DaemonResponse,
+  DartFrogApplication,
+  StopDaemonRequest,
+} from "../../../daemon";
+import * as assert from "assert";
+import { Uri } from "vscode";
+
+suite("debug-dev-server command", () => {
+  const application1 = new DartFrogApplication("workingDirectory1", 8080, 8181);
+  application1.id = "application1";
+  application1.address = `http://localhost:${application1.port}`;
+  application1.vmServiceUri = `http://localhost:${application1.vmServicePort}`;
+
+  const application2 = new DartFrogApplication("workingDirectory2", 8081, 8182);
+  application2.id = "application2";
+  application2.address = `http://localhost:${application2.port}`;
+  application2.vmServiceUri = `http://localhost:${application2.vmServicePort}`;
+
+  let vscodeStub: any;
+  let utilsStub: any;
+  let daemon: any;
+  let command: any;
+  let dartCodeExtension: any;
+
+  beforeEach(() => {
+    vscodeStub = {
+      window: {
+        showInformationMessage: sinon.stub(),
+        showErrorMessage: sinon.stub(),
+        withProgress: sinon.stub(),
+      },
+      commands: {
+        executeCommand: sinon.stub(),
+      },
+      extensions: {
+        getExtension: sinon.stub(),
+      },
+      debug: {
+        startDebugging: sinon.stub(),
+        activeDebugSession: undefined,
+      },
+    };
+    dartCodeExtension = sinon.stub();
+    dartCodeExtension.activate = sinon.stub();
+    dartCodeExtension.isActive = true;
+    vscodeStub.extensions.getExtension
+      .withArgs("Dart-Code.dart-code")
+      .returns(dartCodeExtension);
+
+    utilsStub = {
+      isDartFrogCLIInstalled: sinon.stub(),
+      suggestInstallingDartFrogCLI: sinon.stub(),
+      quickPickApplication: sinon.stub(),
+    };
+    utilsStub.isDartFrogCLIInstalled.returns(true);
+
+    const dartFrogDaemon = {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      DartFrogDaemon: sinon.stub(),
+    };
+    dartFrogDaemon.DartFrogDaemon.instance = sinon.stub();
+    daemon = dartFrogDaemon.DartFrogDaemon.instance;
+    daemon.applicationRegistry = sinon.stub();
+    daemon.applicationRegistry.all = sinon.stub();
+    daemon.applicationRegistry.all.returns([]);
+    daemon.isReady = true;
+
+    command = proxyquire("../../../commands/debug-dev-server", {
+      vscode: vscodeStub,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      "../utils": utilsStub,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      "../daemon": dartFrogDaemon,
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  suite("installing Dart Frog CLI", () => {
+    beforeEach(() => {
+      daemon.isReady = false;
+      daemon.applicationRegistry.all.returns([]);
+    });
+
+    test("is suggested when not installed", async () => {
+      utilsStub.isDartFrogCLIInstalled.returns(false);
+
+      await command.debugDevServer();
+
+      sinon.assert.calledOnceWithExactly(
+        utilsStub.suggestInstallingDartFrogCLI,
+        "Running this command requires Dart Frog CLI to be installed."
+      );
+    });
+
+    test("is not suggested when already installed", async () => {
+      utilsStub.isDartFrogCLIInstalled.returns(true);
+
+      await command.debugDevServer();
+
+      sinon.assert.notCalled(utilsStub.suggestInstallingDartFrogCLI);
+    });
+  });
+
+  suite("installing Dart extension", () => {
+    const message = "Running this command requires the Dart extension.";
+    const installOption = "Install Dart extension";
+    const cancelOption = "Cancel";
+
+    test("is suggested when not installed", async () => {
+      vscodeStub.extensions.getExtension
+        .withArgs("Dart-Code.dart-code")
+        .returns(undefined);
+
+      await command.debugDevServer();
+
+      sinon.assert.calledOnceWithExactly(
+        vscodeStub.window.showErrorMessage,
+        message,
+        installOption,
+        cancelOption
+      );
+    });
+
+    test("is not suggested when already installed", async () => {
+      vscodeStub.extensions.getExtension
+        .withArgs("Dart-Code.dart-code")
+        .returns(dartCodeExtension);
+
+      await command.debugDevServer();
+
+      sinon.assert.notCalled(
+        vscodeStub.window.showErrorMessage.withArgs(
+          message,
+          installOption,
+          cancelOption
+        )
+      );
+    });
+
+    test("`Install Dart extension` option runs install command", async () => {
+      vscodeStub.extensions.getExtension
+        .withArgs("Dart-Code.dart-code")
+        .returns(undefined);
+      vscodeStub.window.showErrorMessage
+        .withArgs(message, installOption, cancelOption)
+        .resolves(installOption);
+
+      await command.debugDevServer();
+
+      sinon.assert.calledOnceWithExactly(
+        vscodeStub.commands.executeCommand,
+        "vscode.open",
+        Uri.parse(
+          "https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code"
+        )
+      );
+    });
+
+    suite("never starts debug session", () => {
+      test("when `Install Dart extension` option is selected", async () => {
+        vscodeStub.extensions.getExtension
+          .withArgs("Dart-Code.dart-code")
+          .returns(undefined);
+        vscodeStub.window.showErrorMessage
+          .withArgs(message, installOption, cancelOption)
+          .resolves(installOption);
+
+        await command.debugDevServer();
+
+        sinon.assert.notCalled(vscodeStub.debug.startDebugging);
+      });
+
+      test("when `Cancel` option is selected", async () => {
+        vscodeStub.extensions.getExtension
+          .withArgs("Dart-Code.dart-code")
+          .returns(undefined);
+        vscodeStub.window.showErrorMessage
+          .withArgs(message, installOption, cancelOption)
+          .resolves(cancelOption);
+
+        await command.debugDevServer();
+
+        sinon.assert.notCalled(vscodeStub.debug.startDebugging);
+      });
+
+      test("when dismissed", async () => {
+        vscodeStub.extensions.getExtension
+          .withArgs("Dart-Code.dart-code")
+          .returns(undefined);
+        vscodeStub.window.showErrorMessage
+          .withArgs(message, installOption, cancelOption)
+          .resolves(undefined);
+
+        await command.debugDevServer();
+
+        sinon.assert.notCalled(vscodeStub.debug.startDebugging);
+      });
+    });
+  });
+
+  suite("Dart extension", () => {
+    test("is activated when not active", async () => {
+      dartCodeExtension.isActive = false;
+
+      await command.debugDevServer();
+
+      sinon.assert.calledOnceWithExactly(
+        vscodeStub.window.withProgress,
+        {
+          location: 15,
+          title: `Activating Dart extension...`,
+        },
+        sinon.match.any
+      );
+
+      const progressFunction =
+        vscodeStub.window.withProgress.getCall(0).args[1];
+      await progressFunction();
+
+      sinon.assert.calledOnceWithExactly(dartCodeExtension.activate);
+    });
+
+    test("is not activated when already active", async () => {
+      dartCodeExtension.isActive = true;
+
+      await command.debugDevServer();
+
+      sinon.assert.notCalled(
+        vscodeStub.window.withProgress.withArgs(
+          {
+            location: 15,
+            title: `Activating Dart extension...`,
+          },
+          sinon.match.any
+        )
+      );
+
+      sinon.assert.notCalled(dartCodeExtension.activate);
+    });
+  });
+
+  suite("no running servers information", () => {
+    const message = "No running servers found.";
+    const startOption = "Start server";
+    const cancelOption = "Cancel";
+
+    suite("is shown", () => {
+      test("when daemon is not ready", async () => {
+        daemon.isReady = false;
+        daemon.applicationRegistry.all.returns([]);
+
+        await command.debugDevServer();
+
+        sinon.assert.calledOnceWithExactly(
+          vscodeStub.window.showInformationMessage,
+          message,
+          startOption,
+          cancelOption
+        );
+      });
+
+      test("when daemon is ready but no application is registered", async () => {
+        daemon.isReady = true;
+        daemon.applicationRegistry.all.returns([]);
+
+        await command.debugDevServer();
+
+        sinon.assert.calledOnceWithExactly(
+          vscodeStub.window.showInformationMessage,
+          message,
+          startOption,
+          cancelOption
+        );
+      });
+    });
+
+    test("is not shown when daemon is ready and applications are registered", async () => {
+      daemon.isReady = true;
+      daemon.applicationRegistry.all.returns([
+        new DartFrogApplication("workingDirectory", 8080, 8181),
+      ]);
+
+      await command.debugDevServer();
+
+      sinon.assert.notCalled(
+        vscodeStub.window.showInformationMessage.withArgs(
+          message,
+          startOption,
+          cancelOption
+        )
+      );
+    });
+
+    test("start server option runs start server command", async () => {
+      daemon.isReady = false;
+      daemon.applicationRegistry.all.returns([]);
+
+      vscodeStub.window.showInformationMessage
+        .withArgs(message, startOption, cancelOption)
+        .resolves(startOption);
+
+      await command.debugDevServer();
+
+      sinon.assert.calledOnceWithExactly(
+        vscodeStub.commands.executeCommand,
+        "dart-frog.start-dev-server"
+      );
+    });
+
+    suite("never starts debug session", () => {
+      beforeEach(() => {
+        daemon.isReady = false;
+        daemon.applicationRegistry.all.returns([]);
+      });
+
+      test("when `Start server` option is selected", async () => {
+        vscodeStub.window.showInformationMessage
+          .withArgs(message, startOption, cancelOption)
+          .resolves(startOption);
+
+        await command.debugDevServer();
+
+        sinon.assert.notCalled(vscodeStub.debug.startDebugging);
+      });
+
+      test("when `Cancel` option is selected", async () => {
+        vscodeStub.window.showInformationMessage
+          .withArgs(message, startOption, cancelOption)
+          .resolves(cancelOption);
+
+        await command.debugDevServer();
+
+        sinon.assert.notCalled(vscodeStub.debug.startDebugging);
+      });
+
+      test("when dismissed", async () => {
+        vscodeStub.window.showInformationMessage
+          .withArgs(message, startOption, cancelOption)
+          .resolves(undefined);
+
+        await command.debugDevServer();
+
+        sinon.assert.notCalled(vscodeStub.debug.startDebugging);
+      });
+    });
+  });
+
+  suite("applications quick pick", () => {
+    test("is not shown when there is a single running application", async () => {
+      daemon.applicationRegistry.all.returns([application1]);
+
+      await command.debugDevServer();
+
+      sinon.assert.notCalled(utilsStub.quickPickApplication);
+    });
+
+    test("is shown when there is more than a single running application", async () => {
+      daemon.applicationRegistry.all.returns([application1, application2]);
+      utilsStub.quickPickApplication.resolves(application1);
+
+      await command.debugDevServer();
+
+      sinon.assert.calledOnceWithExactly(
+        utilsStub.quickPickApplication,
+        {
+          placeHolder: "Select a server to debug",
+        },
+        [application1, application2]
+      );
+    });
+
+    test("never starts debug session when dismissed", async () => {
+      daemon.applicationRegistry.all.returns([application1, application2]);
+      utilsStub.quickPickApplication.resolves(undefined);
+
+      await command.debugDevServer();
+
+      sinon.assert.notCalled(vscodeStub.debug.startDebugging);
+    });
+  });
+
+  suite("running debug session information", () => {
+    const message = `A debug session is already running for this application.`;
+    const createOption = "Create another debug session";
+    const cancelOption = "Cancel";
+
+    test("is shown when there is already an active debug session for the application", async () => {
+      daemon.applicationRegistry.all.returns([application1]);
+      vscodeStub.debug.activeDebugSession = {
+        configuration: {
+          applicationId: application1.id,
+        },
+      };
+
+      await command.debugDevServer();
+
+      sinon.assert.calledOnceWithExactly(
+        vscodeStub.window.showInformationMessage,
+        message,
+        createOption,
+        cancelOption
+      );
+    });
+
+    suite("is not shown", () => {
+      test("when there are no active debug sessions", async () => {
+        vscodeStub.debug.activeDebugSession = undefined;
+
+        await command.debugDevServer();
+
+        sinon.assert.notCalled(
+          vscodeStub.window.showInformationMessage.withArgs(
+            message,
+            createOption,
+            cancelOption
+          )
+        );
+      });
+
+      test("when there is an active debug session for another application", async () => {
+        daemon.applicationRegistry.all.returns([application1]);
+        vscodeStub.debug.activeDebugSession = {
+          configuration: {
+            applicationId: `not-${application1.id}`,
+          },
+        };
+
+        await command.debugDevServer();
+
+        sinon.assert.notCalled(
+          vscodeStub.window.showInformationMessage.withArgs(
+            message,
+            createOption,
+            cancelOption
+          )
+        );
+      });
+
+      test("does not start debug session when cancelled", async () => {
+        daemon.applicationRegistry.all.returns([application1]);
+        vscodeStub.debug.activeDebugSession = {
+          configuration: {
+            applicationId: application1.id,
+          },
+        };
+        vscodeStub.window.showInformationMessage
+          .withArgs(message, createOption, cancelOption)
+          .resolves(cancelOption);
+
+        await command.debugDevServer();
+
+        sinon.assert.notCalled(vscodeStub.debug.startDebugging);
+      });
+
+      test("does not start debug session when dismissed", async () => {
+        daemon.applicationRegistry.all.returns([application1]);
+        vscodeStub.debug.activeDebugSession = {
+          configuration: {
+            applicationId: application1.id,
+          },
+        };
+        vscodeStub.window.showInformationMessage
+          .withArgs(message, createOption, cancelOption)
+          .resolves(undefined);
+
+        await command.debugDevServer();
+
+        sinon.assert.notCalled(vscodeStub.debug.startDebugging);
+      });
+    });
+  });
+
+  suite("starts debug session", () => {
+    test("when there is a single running application", async () => {
+      vscodeStub.debug.activeDebugSession = undefined;
+
+      daemon.applicationRegistry.all.returns([application1]);
+
+      await command.debugDevServer();
+
+      const progressFunction =
+        vscodeStub.window.withProgress.getCall(0).args[1];
+      await progressFunction();
+
+      sinon.assert.calledOnceWithExactly(
+        vscodeStub.debug.startDebugging,
+        undefined,
+        {
+          name: `Dart Frog: Development Server (${application1.address})`,
+          request: "attach",
+          type: "dart",
+          vmServiceUri: application1.vmServiceUri,
+          applicationId: application1.id,
+        }
+      );
+    });
+
+    test("when there is more than one running application and debug session", async () => {
+      daemon.applicationRegistry.all.returns([application1, application2]);
+      utilsStub.quickPickApplication.resolves(application1);
+      vscodeStub.debug.activeDebugSession = {
+        configuration: {
+          applicationId: application1.id,
+        },
+      };
+      vscodeStub.window.showInformationMessage.resolves(
+        "Create another debug session"
+      );
+
+      await command.debugDevServer();
+
+      const progressFunction =
+        vscodeStub.window.withProgress.getCall(0).args[1];
+      await progressFunction();
+
+      sinon.assert.calledOnceWithExactly(
+        vscodeStub.debug.startDebugging,
+        undefined,
+        {
+          name: `Dart Frog: Development Server (${application1.address})`,
+          request: "attach",
+          type: "dart",
+          vmServiceUri: application1.vmServiceUri,
+          applicationId: application1.id,
+        }
+      );
+    });
+  });
+});

--- a/extensions/vscode/src/test/suite/commands/debug-dev-server.test.ts
+++ b/extensions/vscode/src/test/suite/commands/debug-dev-server.test.ts
@@ -84,11 +84,6 @@ suite("debug-dev-server command", () => {
   });
 
   suite("installing Dart Frog CLI", () => {
-    beforeEach(() => {
-      daemon.isReady = false;
-      daemon.applicationRegistry.all.returns([]);
-    });
-
     test("is suggested when not installed", async () => {
       utilsStub.isDartFrogCLIInstalled.returns(false);
 
@@ -145,7 +140,7 @@ suite("debug-dev-server command", () => {
       );
     });
 
-    test("`Install Dart extension` option runs install command", async () => {
+    test("`Install Dart extension` option opens marketplace", async () => {
       vscodeStub.extensions.getExtension
         .withArgs("Dart-Code.dart-code")
         .returns(undefined);

--- a/extensions/vscode/src/test/suite/commands/debug-dev-server.test.ts
+++ b/extensions/vscode/src/test/suite/commands/debug-dev-server.test.ts
@@ -2,12 +2,7 @@ const sinon = require("sinon");
 var proxyquire = require("proxyquire");
 
 import { afterEach, beforeEach } from "mocha";
-import {
-  DaemonResponse,
-  DartFrogApplication,
-  StopDaemonRequest,
-} from "../../../daemon";
-import * as assert from "assert";
+import { DartFrogApplication } from "../../../daemon";
 import { Uri } from "vscode";
 
 suite("debug-dev-server command", () => {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Allows attaching a development server to Dart's debugger via the command palette.

Changes:

- Registers debug-dev-server command

## Demonstration

https://github.com/VeryGoodOpenSource/dart_frog/assets/44524995/75f07036-d742-41f0-aa90-8c8e12b4a365

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
