### PR TITLE
feat(vscode): open server with current route path

### DIFF
--- a/extensions/vscode/src/commands/start-dev-server.ts
+++ b/extensions/vscode/src/commands/start-dev-server.ts
@@ -7,6 +7,7 @@ import {
 } from "../daemon";
 import { Uri, commands, window } from "vscode";
 import {
+  currentRoutePath,
   isDartFrogCLIInstalled,
   nearestDartFrogProject,
   resolveDartFrogProjectPathFromWorkspace,
@@ -133,7 +134,10 @@ export const startDevServer = async (): Promise<
         increment: 100,
       });
 
-      commands.executeCommand("vscode.open", Uri.parse(application.address!));
+      commands.executeCommand(
+        "vscode.open",
+        Uri.parse(application.address! + currentRoutePath())
+      );
 
       return application;
     }

--- a/extensions/vscode/src/status-bar/open-application-status-bar-item.ts
+++ b/extensions/vscode/src/status-bar/open-application-status-bar-item.ts
@@ -4,6 +4,7 @@ import {
   DartFrogDaemon,
 } from "../daemon";
 import { DartFrogStatusBarItem } from "./dart-frog-status-bar-item";
+import { currentRoutePath } from "../utils";
 
 export class OpenApplicationStatusBarItem extends DartFrogStatusBarItem {
   private updateFunction: () => void;
@@ -35,10 +36,11 @@ export class OpenApplicationStatusBarItem extends DartFrogStatusBarItem {
     const application = applications[0];
     this.statusBarItem.text = `$(dart-frog-globe) localhost:${application.port}`;
     this.statusBarItem.tooltip = "Open application in browser";
+
     const openCommand: Command = {
       title: "Open application in browser",
       command: "vscode.open",
-      arguments: [Uri.parse(application.address!)],
+      arguments: [Uri.parse(application.address! + currentRoutePath())],
     };
     this.statusBarItem.command = openCommand;
     this.statusBarItem.show();

--- a/extensions/vscode/src/utils/dart-frog-structure.ts
+++ b/extensions/vscode/src/utils/dart-frog-structure.ts
@@ -154,3 +154,31 @@ export function resolveDartFrogProjectPathFromWorkspace(
 
   return undefined;
 }
+
+/**
+ * Deduces the current route path from the active workspace file or folder of a
+ * of a Dart Frog project.
+ *
+ * @returns {string} The current route path of a Dart Frog project. If the user
+ * has a Dart file or workspace open in the editor that is under a `routes`
+ * directory and within a Dart Frog project, then the path of that file is
+ * returned. Otherwise, an empty string is returned.
+ */
+export function currentRoutePath(): string {
+  const workingPath = resolveDartFrogProjectPathFromWorkspace();
+  if (workingPath) {
+    const dartFrogProjectPath = nearestDartFrogProject(workingPath);
+    const routePath = normalizeRoutePath(workingPath, dartFrogProjectPath!);
+    const isRoot = routePath === "/" || routePath === "";
+
+    if (isRoot) {
+      return "";
+    } else if (!routePath.startsWith("/")) {
+      return `/${routePath}`;
+    } else {
+      return routePath;
+    }
+  }
+
+  return "";
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**IN DEVELOPMENT**

## Description

Completely resolves #957 .

When opening the server's address on the browser, either via starting a development server or the status bar item, it considers the current route path and appends it to the address. This route path is deduced from the active file or directory, if possible.

## Demonstration

https://github.com/VeryGoodOpenSource/dart_frog/assets/44524995/7da95e5e-60da-4863-9f0c-feb226e2c805

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
