### PR TITLE
docs: add daemon request format warning

### DIFF
--- a/docs/docs/advanced/daemon.md
+++ b/docs/docs/advanced/daemon.md
@@ -40,6 +40,10 @@ $ dart_frog daemon
 
 The `id` field on the request is used to match the request with the response. As the client sets it arbitrarily, the client is responsible for ensuring that all request ids are unique.
 
+:::warning
+The requests should be strictly in the format `[{...}]`. Therefore, sending a request with any of these formats: `[{...},]`, `[{<...>}, {<...>}]` or `[{<...>}]\n[{<...>}]` is problematic.
+:::
+
 ---
 
 # Domains

--- a/docs/docs/advanced/daemon.md
+++ b/docs/docs/advanced/daemon.md
@@ -41,7 +41,7 @@ $ dart_frog daemon
 The `id` field on the request is used to match the request with the response. As the client sets it arbitrarily, the client is responsible for ensuring that all request ids are unique.
 
 :::warning
-The requests should be strictly in the format `[{...}]`. Therefore, sending a request with any of these formats: `[{...},]`, `[{<...>}, {<...>}]` or `[{<...>}]\n[{<...>}]` is problematic.
+The requests should be strictly in the format `[{...}]`. Therefore, sending a request with any of these formats: `[{...},]`, `[{...}, {...}]` or `[{...}]\n[{...}]` is problematic.
 :::
 
 ---

--- a/docs/docs/advanced/daemon.md
+++ b/docs/docs/advanced/daemon.md
@@ -41,7 +41,7 @@ $ dart_frog daemon
 The `id` field on the request is used to match the request with the response. As the client sets it arbitrarily, the client is responsible for ensuring that all request ids are unique.
 
 :::warning
-The requests should be strictly in the format `[{...}]`. Therefore, sending a request with any of these formats: `[{...},]`, `[{...}, {...}]` or `[{...}]\n[{...}]` is problematic.
+The requests should be strictly in the format `[{...}]`. Therefore, sending a request with any of these formats: `[{...},]`, `[{...}, {...}]` or `[{...}]\n[{...}]` is currently not accepted.
 :::
 
 ---


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Add a format warning regarding requests.

Since something as the following will succeed but only apply to the first request. This usage is considerded problematic and should not be used.
```sh
[{"id":"1","method":"dev_server.start","params":{"workingDirectory":"/Users/alestiago/Developer/workspace/oss/issues/sample","port":8080,"dartVmServicePort":8181}},{"id":"2","method":"dev_server.start","params":{"workingDirectory":"/Users/alestiago/Developer/workspace/oss/issues/sample","port":8080,"dartVmServicePort":8181}}]
```

(cc: @renancaraujo )

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
