### PR TITLE
fix(vscode): support CodeLens for very long route signatures

### DIFF
--- a/extensions/vscode/src/code-lens/on-request-code-lens.ts
+++ b/extensions/vscode/src/code-lens/on-request-code-lens.ts
@@ -77,7 +77,7 @@ abstract class RegularExpressionCodeLensProvider extends ConfigurableCodeLensPro
 abstract class OnRequestCodeLensProvider extends RegularExpressionCodeLensProvider {
   readonly regex: RegExp =
     // eslint-disable-next-line max-len
-    /(Response|Future<Response>|FutureOr<Response>)\s*onRequest\(RequestContext .*?\)\s*(?:async)?\s*{/g;
+    /(Response|Future<Response>|FutureOr<Response>)\s*onRequest\(.*?/g;
 
   public provideCodeLenses(document: TextDocument): ProviderResult<CodeLens[]> {
     if (document.languageId !== "dart") {

--- a/extensions/vscode/src/test/suite/code-lens/on-request-code-lens.test.ts
+++ b/extensions/vscode/src/test/suite/code-lens/on-request-code-lens.test.ts
@@ -65,6 +65,23 @@ Response notOnRequest(RequestContext context) {
 
 `;
 
+/**
+ * A very long dynamic route with multiple arguments.
+ */
+const longDynamicRouteContent = `
+import 'package:dart_frog/dart_frog.dart';
+
+Response onRequest(
+  RequestContext context,
+  String id1,
+  String id2,
+  String id3,
+) {
+  return Response(body: 'Welcome to Dart Frog!');
+}
+
+`;
+
 suite("RunOnRequestCodeLensProvider", () => {
   let vscodeStub: any;
   let utilsStub: any;
@@ -221,6 +238,33 @@ suite("RunOnRequestCodeLensProvider", () => {
 
     test("returns the correct CodeLenses on a dynamic route", async () => {
       const content = dynamicRouteContent;
+      const textDocument = await workspace.openTextDocument({
+        language: "text",
+        content,
+      });
+      document.getText = textDocument.getText.bind(textDocument);
+      document.positionAt = textDocument.positionAt.bind(textDocument);
+      document.lineAt = textDocument.lineAt.bind(textDocument);
+      document.getWordRangeAtPosition =
+        textDocument.getWordRangeAtPosition.bind(textDocument);
+
+      const provider = new RunOnRequestCodeLensProvider();
+      const result = await provider.provideCodeLenses(document);
+
+      assert.strictEqual(result.length, 1);
+
+      const codeLens = result[0];
+
+      const range = document.getWordRangeAtPosition(
+        new Position(3, 0),
+        provider.regex
+      )!;
+
+      sinon.assert.match(codeLens, new CodeLens(range));
+    });
+
+    test("returns the correct CodeLenses on a long dynamic route", async () => {
+      const content = longDynamicRouteContent;
       const textDocument = await workspace.openTextDocument({
         language: "text",
         content,
@@ -530,6 +574,33 @@ suite("DebugOnRequestCodeLensProvider", () => {
 
     test("returns the correct CodeLenses on a dynamic route", async () => {
       const content = dynamicRouteContent;
+      const textDocument = await workspace.openTextDocument({
+        language: "text",
+        content,
+      });
+      document.getText = textDocument.getText.bind(textDocument);
+      document.positionAt = textDocument.positionAt.bind(textDocument);
+      document.lineAt = textDocument.lineAt.bind(textDocument);
+      document.getWordRangeAtPosition =
+        textDocument.getWordRangeAtPosition.bind(textDocument);
+
+      const provider = new DebugOnRequestCodeLensProvider();
+      const result = await provider.provideCodeLenses(document);
+
+      assert.strictEqual(result.length, 1);
+
+      const codeLens = result[0];
+
+      const range = document.getWordRangeAtPosition(
+        new Position(3, 0),
+        provider.regex
+      )!;
+
+      sinon.assert.match(codeLens, new CodeLens(range));
+    });
+
+    test("returns the correct CodeLenses on a long dynamic route", async () => {
+      const content = longDynamicRouteContent;
       const textDocument = await workspace.openTextDocument({
         language: "text",
         content,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Updates the Regular Expression to support long route signatures.

The Regular Expression will now ignore the RequestContext as the first parameter. @wolfenrain and I are not to worry about it. Eventually, we will replace the RegExp by analysing the AST.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
