### PR TITLE
fix(dart_frog_cli): report daemon missing parameters

### DIFF
--- a/packages/dart_frog_cli/lib/src/daemon/domain/dev_server_domain.dart
+++ b/packages/dart_frog_cli/lib/src/daemon/domain/dev_server_domain.dart
@@ -36,24 +36,11 @@ class DevServerDomain extends DomainBase {
 
   /// Starts a [DevServerRunner] for the given [request].
   Future<DaemonResponse> _start(DaemonRequest request) async {
-    final workingDirectory = request.params?['workingDirectory'];
-    if (workingDirectory is! String) {
-      throw const DartFrogDaemonMalformedMessageException(
-        'invalid workingDirectory',
-      );
-    }
+    final workingDirectory = request.getParam<String>('workingDirectory');
 
-    final port = request.params?['port'];
-    if (port is! int) {
-      throw const DartFrogDaemonMalformedMessageException('invalid port');
-    }
+    final port = request.getParam<int>('port');
 
-    final dartVmServicePort = request.params?['dartVmServicePort'];
-    if (dartVmServicePort is! int) {
-      throw const DartFrogDaemonMalformedMessageException(
-        'invalid dartVmServicePort',
-      );
-    }
+    final dartVmServicePort = request.getParam<int>('dartVmServicePort');
 
     final applicationId = getId();
 
@@ -127,12 +114,7 @@ class DevServerDomain extends DomainBase {
   }
 
   Future<DaemonResponse> _reload(DaemonRequest request) async {
-    final applicationId = request.params?['applicationId'];
-    if (applicationId is! String) {
-      throw const DartFrogDaemonMalformedMessageException(
-        'invalid applicationId',
-      );
-    }
+    final applicationId = request.getParam<String>('applicationId');
 
     final runner = _devServerRunners[applicationId];
     if (runner == null) {
@@ -166,12 +148,7 @@ class DevServerDomain extends DomainBase {
   }
 
   Future<DaemonResponse> _stop(DaemonRequest request) async {
-    final applicationId = request.params?['applicationId'];
-    if (applicationId is! String) {
-      throw const DartFrogDaemonMalformedMessageException(
-        'invalid applicationId',
-      );
-    }
+    final applicationId = request.getParam<String>('applicationId');
 
     final runner = _devServerRunners.remove(applicationId);
     if (runner == null) {

--- a/packages/dart_frog_cli/lib/src/daemon/domain/route_configuration_domain.dart
+++ b/packages/dart_frog_cli/lib/src/daemon/domain/route_configuration_domain.dart
@@ -34,12 +34,7 @@ class RouteConfigurationDomain extends DomainBase {
   final RouteConfigurationWatcherBuilder _routeConfigWatcherBuilder;
 
   Future<DaemonResponse> _watcherStart(DaemonRequest request) async {
-    final workingDirectory = request.params?['workingDirectory'];
-    if (workingDirectory is! String) {
-      throw const DartFrogDaemonMalformedMessageException(
-        'invalid workingDirectory',
-      );
-    }
+    final workingDirectory = request.getParam<String>('workingDirectory');
 
     final watcherId = getId();
 
@@ -128,12 +123,7 @@ class RouteConfigurationDomain extends DomainBase {
   Future<DaemonResponse> _watcherGenerateRouteConfiguration(
     DaemonRequest request,
   ) async {
-    final watcherId = request.params?['watcherId'];
-    if (watcherId is! String) {
-      throw const DartFrogDaemonMalformedMessageException(
-        'invalid watcherId',
-      );
-    }
+    final watcherId = request.getParam<String>('watcherId');
 
     final watcher = _routeConfigurationWatchers[watcherId];
     if (watcher == null) {
@@ -168,12 +158,7 @@ class RouteConfigurationDomain extends DomainBase {
   }
 
   Future<DaemonResponse> _watcherStop(DaemonRequest request) async {
-    final watcherId = request.params?['watcherId'];
-    if (watcherId is! String) {
-      throw const DartFrogDaemonMalformedMessageException(
-        'invalid watcherId',
-      );
-    }
+    final watcherId = request.getParam<String>('watcherId');
 
     final watcher = _routeConfigurationWatchers.remove(watcherId);
     if (watcher == null) {

--- a/packages/dart_frog_cli/lib/src/daemon/exceptions.dart
+++ b/packages/dart_frog_cli/lib/src/daemon/exceptions.dart
@@ -27,3 +27,14 @@ class DartFrogDaemonMalformedMessageException
   const DartFrogDaemonMalformedMessageException(String message)
       : super('Malformed message, $message');
 }
+
+/// {@template dart_frog_daemon_missing_parameter_exception}
+/// An exception thrown when the daemon reports
+/// a missing parameter of a message.
+/// {@endtemplate}
+class DartFrogDaemonMissingParameterException
+    extends DartFrogDaemonMessageException {
+  /// {@macro dart_frog_daemon_malformed_message_exception}
+  const DartFrogDaemonMissingParameterException(String message)
+      : super('Missing parameter, $message');
+}

--- a/packages/dart_frog_cli/lib/src/daemon/exceptions.dart
+++ b/packages/dart_frog_cli/lib/src/daemon/exceptions.dart
@@ -29,8 +29,8 @@ class DartFrogDaemonMalformedMessageException
 }
 
 /// {@template dart_frog_daemon_missing_parameter_exception}
-/// An exception thrown when the daemon reports
-/// a missing parameter of a message.
+/// An exception thrown when the daemon reports a missing parameter of a
+/// message.
 /// {@endtemplate}
 class DartFrogDaemonMissingParameterException
     extends DartFrogDaemonMessageException {

--- a/packages/dart_frog_cli/lib/src/daemon/protocol.dart
+++ b/packages/dart_frog_cli/lib/src/daemon/protocol.dart
@@ -118,6 +118,46 @@ class DaemonRequest extends DaemonMessage {
 
   @override
   List<Object?> get props => [id, method, params, domain];
+
+  ///
+  /// Gets a parameter of this request.
+  ///
+  /// Throws a [DartFrogDaemonMissingParameterException] if the parameter
+  /// is not found and type [T] is not nullable.
+  ///
+  /// Throws a [DartFrogDaemonMalformedMessageException] if the parameter
+  /// is not of type [T].
+  ///
+  /// Required parameters should be typed as not nullable
+  ///   `final paramValue = getParam<String>('requiredValue')`.
+  ///
+  /// Optional parameters should be typed as nullable
+  ///  `final paramValue = getParam<String?>('optionalValue')`.
+  ///
+  T getParam<T>(String name) {
+    final params = this.params;
+
+    if (params == null) {
+      throw const DartFrogDaemonMalformedMessageException(
+        'Missing params object',
+      );
+    }
+
+    final param = params[name];
+    if (param is! T) {
+      // Check if param type is optional or not
+      if (param == null && null is! T) {
+        throw DartFrogDaemonMissingParameterException(
+          '$name not found',
+        );
+      }
+      throw DartFrogDaemonMalformedMessageException(
+        'invalid $name',
+      );
+    }
+
+    return param;
+  }
 }
 
 /// {@template daemon_response}

--- a/packages/dart_frog_cli/test/src/daemon/domain/dev_server_domain_test.dart
+++ b/packages/dart_frog_cli/test/src/daemon/domain/dev_server_domain_test.dart
@@ -122,6 +122,77 @@ void main() {
         ).called(1);
       });
 
+      group('missing parameters', () {
+        test('workingDirectory', () async {
+          expect(
+            await domain.handleRequest(
+              const DaemonRequest(
+                id: '12',
+                domain: 'dev_server',
+                method: 'start',
+                params: {'port': 3000, 'dartVmServicePort': 3001},
+              ),
+            ),
+            equals(
+              const DaemonResponse.error(
+                id: '12',
+                error: {
+                  'message': 'Missing parameter, workingDirectory not found',
+                },
+              ),
+            ),
+          );
+        });
+
+        test('port', () async {
+          expect(
+            await domain.handleRequest(
+              const DaemonRequest(
+                id: '12',
+                domain: 'dev_server',
+                method: 'start',
+                params: {
+                  'workingDirectory': '/',
+                  'dartVmServicePort': 3001,
+                },
+              ),
+            ),
+            equals(
+              const DaemonResponse.error(
+                id: '12',
+                error: {
+                  'message': 'Missing parameter, port not found',
+                },
+              ),
+            ),
+          );
+        });
+
+        test('dartVmServicePort', () async {
+          expect(
+            await domain.handleRequest(
+              const DaemonRequest(
+                id: '12',
+                domain: 'dev_server',
+                method: 'start',
+                params: {
+                  'workingDirectory': '/',
+                  'port': 3000,
+                },
+              ),
+            ),
+            equals(
+              const DaemonResponse.error(
+                id: '12',
+                error: {
+                  'message': 'Missing parameter, dartVmServicePort not found',
+                },
+              ),
+            ),
+          );
+        });
+      });
+
       group('malformed messages', () {
         test('workingDirectory', () async {
           expect(
@@ -277,6 +348,29 @@ void main() {
           );
         });
 
+        group('missing parameters', () {
+          test('applicationId', () async {
+            expect(
+              await domain.handleRequest(
+                const DaemonRequest(
+                  id: '12',
+                  domain: 'dev_server',
+                  method: 'reload',
+                  params: {},
+                ),
+              ),
+              equals(
+                const DaemonResponse.error(
+                  id: '12',
+                  error: {
+                    'message': 'Missing parameter, applicationId not found',
+                  },
+                ),
+              ),
+            );
+          });
+        });
+
         test('application not found', () async {
           expect(
             await domain.handleRequest(
@@ -385,6 +479,29 @@ void main() {
               ),
             ),
           );
+        });
+
+        group('missing parameters', () {
+          test('applicationId', () async {
+            expect(
+              await domain.handleRequest(
+                const DaemonRequest(
+                  id: '12',
+                  domain: 'dev_server',
+                  method: 'stop',
+                  params: {},
+                ),
+              ),
+              equals(
+                const DaemonResponse.error(
+                  id: '12',
+                  error: {
+                    'message': 'Missing parameter, applicationId not found',
+                  },
+                ),
+              ),
+            );
+          });
         });
 
         test('application not found', () async {

--- a/packages/dart_frog_cli/test/src/daemon/domain/route_configuration_domain_test.dart
+++ b/packages/dart_frog_cli/test/src/daemon/domain/route_configuration_domain_test.dart
@@ -166,6 +166,29 @@ void main() {
         });
       });
 
+      group('missing parameters', () {
+        test('workingDirectory', () async {
+          expect(
+            await domain.handleRequest(
+              const DaemonRequest(
+                id: '12',
+                domain: 'route_configuration',
+                method: 'watcherStart',
+                params: {},
+              ),
+            ),
+            equals(
+              const DaemonResponse.error(
+                id: '12',
+                error: {
+                  'message': 'Missing parameter, workingDirectory not found',
+                },
+              ),
+            ),
+          );
+        });
+      });
+
       test('on dev server throw', () async {
         when(() => watcher.start()).thenThrow('error');
 
@@ -269,6 +292,29 @@ void main() {
                 error: {
                   'watcherId': 'different-id',
                   'message': 'Watcher not found',
+                },
+              ),
+            ),
+          );
+        });
+      });
+
+      group('missing parameters', () {
+        test('watcherId', () async {
+          expect(
+            await domain.handleRequest(
+              const DaemonRequest(
+                id: '12',
+                domain: 'route_configuration',
+                method: 'watcherStop',
+                params: {},
+              ),
+            ),
+            equals(
+              const DaemonResponse.error(
+                id: '12',
+                error: {
+                  'message': 'Missing parameter, watcherId not found',
                 },
               ),
             ),
@@ -414,6 +460,29 @@ void main() {
                 error: {
                   'watcherId': 'different-id',
                   'message': 'Watcher not found',
+                },
+              ),
+            ),
+          );
+        });
+      });
+
+      group('missing parameters', () {
+        test('watcherId', () async {
+          expect(
+            await domain.handleRequest(
+              const DaemonRequest(
+                id: '12',
+                domain: 'route_configuration',
+                method: 'watcherGenerateRouteConfiguration',
+                params: {},
+              ),
+            ),
+            equals(
+              const DaemonResponse.error(
+                id: '12',
+                error: {
+                  'message': 'Missing parameter, watcherId not found',
                 },
               ),
             ),

--- a/packages/dart_frog_cli/test/src/daemon/protocol_test.dart
+++ b/packages/dart_frog_cli/test/src/daemon/protocol_test.dart
@@ -207,4 +207,98 @@ void main() {
       );
     });
   });
+
+  group('get request param', () {
+    group('required', () {
+      test('without params', () {
+        expect(
+          () => const DaemonRequest(
+            id: '1',
+            domain: 'foo',
+            method: 'bar',
+          ).getParam<String>('foo'),
+          throwsA(isA<DartFrogDaemonMalformedMessageException>()),
+        );
+      });
+      test('with empty params', () {
+        expect(
+          () => const DaemonRequest(
+            id: '1',
+            domain: 'foo',
+            method: 'bar',
+            params: <String, String>{},
+          ).getParam<String>('foo'),
+          throwsA(isA<DartFrogDaemonMissingParameterException>()),
+        );
+      });
+      test('with other params', () {
+        expect(
+          () => const DaemonRequest(
+            id: '1',
+            domain: 'foo',
+            method: 'bar',
+            params: {'bar': 'baz'},
+          ).getParam<String>('foo'),
+          throwsA(isA<DartFrogDaemonMissingParameterException>()),
+        );
+      });
+      test('with existing param', () {
+        expect(
+          const DaemonRequest(
+            id: '1',
+            domain: 'foo',
+            method: 'bar',
+            params: {'foo': 'bar'},
+          ).getParam<String>('foo'),
+          'bar',
+        );
+      });
+    });
+
+    group('optional', () {
+      test('without params', () {
+        expect(
+          () => const DaemonRequest(
+            id: '1',
+            domain: 'foo',
+            method: 'bar',
+          ).getParam<String?>('foo'),
+          throwsA(isA<DartFrogDaemonMalformedMessageException>()),
+        );
+      });
+      test('with empty params', () {
+        expect(
+          const DaemonRequest(
+            id: '1',
+            domain: 'foo',
+            method: 'bar',
+            params: <String, String>{},
+          ).getParam<String?>('foo'),
+          null,
+        );
+      });
+      test('with other params', () {
+        expect(
+          const DaemonRequest(
+            id: '1',
+            domain: 'foo',
+            method: 'foo.bar',
+            params: {'bar': 'baz'},
+          ).getParam<String?>('foo'),
+          null,
+        );
+      });
+      test('with existing param', () {
+        expect(
+          const DaemonRequest(
+            id: '1',
+            domain: 'foo',
+            method: 'bar',
+            params: {'foo': 'bar'},
+          ).getParam<String?>('foo'),
+          'bar',
+        );
+      });
+    });
+  });
 }


### PR DESCRIPTION

## Status

**READY**

## Description

Fix #913 

`dart_frog_cli` Daemon wil now report missing parameters for `dev_server` and `route_configuration` domains

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
