### PR TITLE
fix(vscode): ensure daemon spawns in shell for Windows compatibility

### DIFF
--- a/extensions/vscode/src/daemon/dart-frog-daemon.ts
+++ b/extensions/vscode/src/daemon/dart-frog-daemon.ts
@@ -142,6 +142,7 @@ export class DartFrogDaemon {
 
     this.process = spawn("dart_frog", ["daemon"], {
       cwd: workingDirectory,
+      shell: true,
     });
     this.process.stdout.on("data", this.stdoutDataListener.bind(this));
 

--- a/extensions/vscode/src/test/suite/daemon/dart-frog-daemon.test.ts
+++ b/extensions/vscode/src/test/suite/daemon/dart-frog-daemon.test.ts
@@ -49,6 +49,7 @@ suite("DartFrogDaemon", () => {
       childProcessStub.spawn
         .withArgs("dart_frog", ["daemon"], {
           cwd: workingDirectory,
+          shell: true,
         })
         .returns(daemonProcess);
 
@@ -73,6 +74,7 @@ suite("DartFrogDaemon", () => {
       childProcessStub.spawn
         .withArgs("dart_frog", ["daemon"], {
           cwd: workingDirectory,
+          shell: true,
         })
         .returns(daemonProcess);
 
@@ -94,6 +96,7 @@ suite("DartFrogDaemon", () => {
       childProcessStub.spawn
         .withArgs("dart_frog", ["daemon"], {
           cwd: workingDirectory,
+          shell: true,
         })
         .returns(daemonProcess);
 
@@ -125,6 +128,7 @@ suite("DartFrogDaemon", () => {
       childProcessStub.spawn
         .withArgs("dart_frog", ["daemon"], {
           cwd: workingDirectory,
+          shell: true,
         })
         .returns(daemonProcess);
 
@@ -235,6 +239,7 @@ suite("DartFrogDaemon", () => {
       childProcessStub.spawn
         .withArgs("dart_frog", ["daemon"], {
           cwd: workingDirectory,
+          shell: true,
         })
         .returns(daemonProcess);
 
@@ -318,6 +323,7 @@ suite("DartFrogDaemon", () => {
       childProcessStub.spawn
         .withArgs("dart_frog", ["daemon"], {
           cwd: workingDirectory,
+          shell: true,
         })
         .returns(daemonProcess);
 
@@ -351,6 +357,7 @@ suite("DartFrogDaemon", () => {
         childProcessStub.spawn
           .withArgs("dart_frog", ["daemon"], {
             cwd: workingDirectory,
+            shell: true,
           })
           .returns(daemonProcess);
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Previously, the spawn would fail to start the child process this was because we need to run in the system shell were `dart_frog` is available.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
