### PR TITLE
refactor(dart_frog_prod_server): remove unused "pathContext" parameter

### DIFF
--- a/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
+++ b/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
@@ -6,13 +6,12 @@ import 'package:path/path.dart' as path;
 
 Future<List<String>> createExternalPackagesFolder(
   Directory directory, {
-  path.Context? pathContext,
   Future<void> Function(String from, String to) copyPath = io.copyPath,
 }) async {
-  final pathResolver = pathContext ?? path.context;
+  final pathResolver = path.context;
   final pubspecLock = await getPubspecLock(
     directory.path,
-    pathContext: pathResolver,
+    pathContext: path.context,
   );
 
   final externalPathDependencies = pubspecLock.packages


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

The `createExternalPackagesFolder` had an unused "pathContext" parameter. This Pull Requests removes it.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
