### PR TITLE
refactor(dart_frog_prod_server): reuse buildDirectory

### DIFF
--- a/bricks/dart_frog_prod_server/hooks/lib/src/create_bundle.dart
+++ b/bricks/dart_frog_prod_server/hooks/lib/src/create_bundle.dart
@@ -4,13 +4,12 @@ import 'package:io/io.dart' show copyPath;
 import 'package:mason/mason.dart';
 import 'package:path/path.dart' as path;
 
-Future<void> createBundle(
-  HookContext context,
-  io.Directory projectDirectory,
-  void Function(int exitCode) exit,
-) async {
-  final buildDirectoryPath = path.join(projectDirectory.path, 'build');
-  final buildDirectory = io.Directory(buildDirectoryPath);
+Future<void> createBundle({
+  required HookContext context,
+  required io.Directory projectDirectory,
+  required io.Directory buildDirectory,
+  required void Function(int exitCode) exit,
+}) async {
   final dartFrogDirectoryPath = path.join(projectDirectory.path, '.dart_frog');
   final dartFrogDirectory = io.Directory(dartFrogDirectoryPath);
   final bundlingProgress = context.logger.progress('Bundling sources');

--- a/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
+++ b/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
@@ -4,13 +4,14 @@ import 'package:dart_frog_prod_server_hooks/dart_frog_prod_server_hooks.dart';
 import 'package:io/io.dart' as io;
 import 'package:path/path.dart' as path;
 
-Future<List<String>> createExternalPackagesFolder(
-  Directory directory, {
+Future<List<String>> createExternalPackagesFolder({
+  required Directory projectDirectory,
+  required Directory buildDirectory,
   Future<void> Function(String from, String to) copyPath = io.copyPath,
 }) async {
   final pathResolver = path.context;
   final pubspecLock = await getPubspecLock(
-    directory.path,
+    projectDirectory.path,
     pathContext: path.context,
   );
 
@@ -43,12 +44,7 @@ Future<List<String>> createExternalPackagesFolder(
     return map;
   });
 
-  final buildDirectory = Directory(
-    pathResolver.join(
-      directory.path,
-      'build',
-    ),
-  )..createSync();
+  buildDirectory.createSync();
 
   final packagesDirectory = Directory(
     pathResolver.join(
@@ -59,7 +55,7 @@ Future<List<String>> createExternalPackagesFolder(
 
   final copiedPaths = <String>[];
   for (final entry in mappedDependencies.entries) {
-    final from = pathResolver.join(directory.path, entry.value);
+    final from = pathResolver.join(projectDirectory.path, entry.value);
     final to = pathResolver.join(packagesDirectory.path, entry.key);
 
     await copyPath(from, to);

--- a/bricks/dart_frog_prod_server/hooks/pre_gen.dart
+++ b/bricks/dart_frog_prod_server/hooks/pre_gen.dart
@@ -34,7 +34,16 @@ Future<void> preGen(
     exit: exit,
   );
 
-  await createBundle(context, projectDirectory, exit);
+  final buildDirectory = io.Directory(
+    path.join(projectDirectory.path, 'build'),
+  );
+
+  await createBundle(
+    context: context,
+    projectDirectory: projectDirectory,
+    buildDirectory: buildDirectory,
+    exit: exit,
+  );
 
   final RouteConfiguration configuration;
   try {
@@ -81,7 +90,8 @@ Future<void> preGen(
   );
 
   final externalDependencies = await createExternalPackagesFolder(
-    projectDirectory,
+    projectDirectory: projectDirectory,
+    buildDirectory: buildDirectory,
     copyPath: copyPath,
   );
 

--- a/bricks/dart_frog_prod_server/hooks/test/src/create_bundle_test.dart
+++ b/bricks/dart_frog_prod_server/hooks/test/src/create_bundle_test.dart
@@ -41,23 +41,36 @@ void main() {
 
     test('exit(1) if bundling throws', () async {
       final exitCalls = <int>[];
-      await createBundle(context, Directory('/invalid/dir'), exitCalls.add);
+      await createBundle(
+        context: context,
+        projectDirectory: Directory('/invalid/dir'),
+        buildDirectory: Directory('/invalid/dir/build'),
+        exit: exitCalls.add,
+      );
       expect(exitCalls, equals([1]));
       verify(() => logger.err(any())).called(1);
     });
 
     test('does not throw when bundling succeeds', () async {
       final exitCalls = <int>[];
-      final directory = Directory.systemTemp.createTempSync();
-      final dotDartFrogDir = Directory(path.join(directory.path, '.dart_frog'))
-        ..createSync();
-      final buildDir = Directory(path.join(directory.path, 'build'))
-        ..createSync();
-      final oldBuildArtifact = File(path.join(buildDir.path, 'artifact.txt'))
-        ..createSync();
-      await createBundle(context, directory, exitCalls.add);
+      final projectDirectory = Directory.systemTemp.createTempSync();
+      final dotDartFrogDir =
+          Directory(path.join(projectDirectory.path, '.dart_frog'))
+            ..createSync();
+      final buildDirectory =
+          Directory(path.join(projectDirectory.path, 'build'))..createSync();
+      final oldBuildArtifact =
+          File(path.join(buildDirectory.path, 'artifact.txt'))..createSync();
+
+      await createBundle(
+        context: context,
+        projectDirectory: projectDirectory,
+        buildDirectory: buildDirectory,
+        exit: exitCalls.add,
+      );
+
       expect(dotDartFrogDir.existsSync(), isFalse);
-      expect(buildDir.existsSync(), isTrue);
+      expect(buildDirectory.existsSync(), isTrue);
       expect(oldBuildArtifact.existsSync(), isFalse);
       expect(exitCalls, isEmpty);
       verifyNever(() => logger.err(any()));

--- a/bricks/dart_frog_prod_server/hooks/test/src/create_external_packages_folder_test.dart
+++ b/bricks/dart_frog_prod_server/hooks/test/src/create_external_packages_folder_test.dart
@@ -11,8 +11,9 @@ void main() {
     test(
       'bundles external dependencies with external dependencies',
       () async {
-        final directory = Directory.systemTemp.createTempSync();
-        File(path.join(directory.path, 'pubspec.yaml')).writeAsStringSync(
+        final projectDirectory = Directory.systemTemp.createTempSync();
+        File(path.join(projectDirectory.path, 'pubspec.yaml'))
+            .writeAsStringSync(
           '''
 name: example
 version: 0.1.0
@@ -26,22 +27,24 @@ dev_dependencies:
   test: any
 ''',
         );
-        File(path.join(directory.path, 'pubspec.lock')).writeAsStringSync(
+        File(path.join(projectDirectory.path, 'pubspec.lock'))
+            .writeAsStringSync(
           fooPath,
         );
         final copyCalls = <String>[];
 
         await createExternalPackagesFolder(
-          directory,
+          projectDirectory: projectDirectory,
+          buildDirectory: Directory(path.join(projectDirectory.path, 'build')),
           copyPath: (from, to) {
             copyCalls.add('$from -> $to');
             return Future.value();
           },
         );
 
-        final from = path.join(directory.path, '../../foo');
+        final from = path.join(projectDirectory.path, '../../foo');
         final to = path.join(
-          directory.path,
+          projectDirectory.path,
           'build',
           '.dart_frog_path_dependencies',
           'foo',
@@ -53,8 +56,9 @@ dev_dependencies:
     test(
       "don't bundle internal path dependencies",
       () async {
-        final directory = Directory.systemTemp.createTempSync();
-        File(path.join(directory.path, 'pubspec.yaml')).writeAsStringSync(
+        final projectDirectory = Directory.systemTemp.createTempSync();
+        File(path.join(projectDirectory.path, 'pubspec.yaml'))
+            .writeAsStringSync(
           '''
 name: example
 version: 0.1.0
@@ -70,14 +74,15 @@ dev_dependencies:
   test: any
 ''',
         );
-        File(path.join(directory.path, 'pubspec.lock')).writeAsStringSync(
+        File(path.join(projectDirectory.path, 'pubspec.lock'))
+            .writeAsStringSync(
           fooPathWithInternalDependency,
         );
         final copyCalls = <String>[];
 
         File(
           path.join(
-            directory.path,
+            projectDirectory.path,
             'packages',
             'bar',
             'pubspec.yaml',
@@ -95,16 +100,17 @@ environment:
           );
 
         await createExternalPackagesFolder(
-          directory,
+          projectDirectory: projectDirectory,
+          buildDirectory: Directory(path.join(projectDirectory.path, 'build')),
           copyPath: (from, to) {
             copyCalls.add('$from -> $to');
             return Future.value();
           },
         );
 
-        final from = path.join(directory.path, '../../foo');
+        final from = path.join(projectDirectory.path, '../../foo');
         final to = path.join(
-          directory.path,
+          projectDirectory.path,
           'build',
           '.dart_frog_path_dependencies',
           'foo',


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Current code has logic for build directory sparse around multiple source files (`create_bundle.dart` and `create_external_packages_folder.dart`), this Pull Request ensures that `buildDirectory` is injected. Ensuring ther is a single place with the logic (i.e.`path.join` statements with magic strings) of where the `buildDirectory` actually is.

It also renames those directories named `directory` that referred to the project directory as `projectDirectory` (more explicit).

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
