### PR TITLE
test(dart_frog_prod_server): remove unnecessary pubspec.yaml setup

### DIFF
--- a/bricks/dart_frog_prod_server/hooks/test/src/create_external_packages_folder_test.dart
+++ b/bricks/dart_frog_prod_server/hooks/test/src/create_external_packages_folder_test.dart
@@ -12,25 +12,8 @@ void main() {
       'bundles external dependencies with external dependencies',
       () async {
         final projectDirectory = Directory.systemTemp.createTempSync();
-        File(path.join(projectDirectory.path, 'pubspec.yaml'))
-            .writeAsStringSync(
-          '''
-name: example
-version: 0.1.0
-environment:
-  sdk: ^2.17.0
-dependencies:
-  mason: any
-  foo:
-    path: ../../foo
-dev_dependencies:
-  test: any
-''',
-        );
         File(path.join(projectDirectory.path, 'pubspec.lock'))
-            .writeAsStringSync(
-          fooPath,
-        );
+            .writeAsStringSync(fooPath);
         final copyCalls = <String>[];
 
         await createExternalPackagesFolder(
@@ -57,47 +40,9 @@ dev_dependencies:
       "don't bundle internal path dependencies",
       () async {
         final projectDirectory = Directory.systemTemp.createTempSync();
-        File(path.join(projectDirectory.path, 'pubspec.yaml'))
-            .writeAsStringSync(
-          '''
-name: example
-version: 0.1.0
-environment:
-  sdk: ^2.17.0
-dependencies:
-  mason: any
-  foo:
-    path: ../../foo
-  bar:
-    path: packages/bar
-dev_dependencies:
-  test: any
-''',
-        );
         File(path.join(projectDirectory.path, 'pubspec.lock'))
-            .writeAsStringSync(
-          fooPathWithInternalDependency,
-        );
+            .writeAsStringSync(fooPathWithInternalDependency);
         final copyCalls = <String>[];
-
-        File(
-          path.join(
-            projectDirectory.path,
-            'packages',
-            'bar',
-            'pubspec.yaml',
-          ),
-        )
-          ..createSync(recursive: true)
-          ..writeAsStringSync(
-            '''
-
-name: bar
-version: 0.1.0
-environment:
-  sdk: ^2.17.0
-            ''',
-          );
 
         await createExternalPackagesFolder(
           projectDirectory: projectDirectory,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

`createExternalPackagesFolder` doesn't use the `pubspec.yaml` that is being setup, it only requires the `pubspec.lock` data which is being provided as a fixture. This Pull Request removes these unnecessary statements.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
