### PR TITLE
refactor(dart_frog_prod_server): clean `createExternalPackagesFolder` logic

### DIFF
--- a/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
+++ b/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
@@ -30,7 +30,7 @@ class _ExternalPathDependency {
   /// The name of the package.
   final String name;
 
-  /// The path to the package.
+  /// The absolute path to the package.
   final String path;
 
   /// Copies the [_ExternalPathDependency] to [targetDirectory].

--- a/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
+++ b/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
@@ -6,41 +6,6 @@ import 'package:path/path.dart' as path;
 
 typedef CopyPath = Future<void> Function(String from, String to);
 
-/// {@template external_path_dependency}
-/// A path dependency that is not within the bundled Dart Frog project
-/// directory.
-///
-/// For example:
-/// ```yaml
-/// name: my_dart_frog_project
-/// dependencies:
-///   my_package:
-///     path: ../my_package
-/// ```
-/// {@endtemplate}
-class _ExternalPathDependency {
-  /// {@macro external_path_dependency}
-  const _ExternalPathDependency({
-    required this.name,
-    required this.path,
-  });
-
-  /// The name of the package.
-  final String name;
-
-  /// The absolute path to the package.
-  final String path;
-
-  /// Copies the [_ExternalPathDependency] to [targetDirectory].
-  Future<_ExternalPathDependency> copyTo({
-    required Directory targetDirectory,
-    CopyPath copyPath = io.copyPath,
-  }) async {
-    await copyPath(path, targetDirectory.path);
-    return _ExternalPathDependency(name: name, path: targetDirectory.path);
-  }
-}
-
 Future<List<String>> createExternalPackagesFolder({
   required Directory projectDirectory,
   required Directory buildDirectory,
@@ -117,4 +82,39 @@ ${copiedExternalPathDependencies.map(
   return copiedExternalPathDependencies
       .map((dependency) => dependency.path)
       .toList();
+}
+
+/// {@template external_path_dependency}
+/// A path dependency that is not within the bundled Dart Frog project
+/// directory.
+///
+/// For example:
+/// ```yaml
+/// name: my_dart_frog_project
+/// dependencies:
+///   my_package:
+///     path: ../my_package
+/// ```
+/// {@endtemplate}
+class _ExternalPathDependency {
+  /// {@macro external_path_dependency}
+  const _ExternalPathDependency({
+    required this.name,
+    required this.path,
+  });
+
+  /// The name of the package.
+  final String name;
+
+  /// The absolute path to the package.
+  final String path;
+
+  /// Copies the [_ExternalPathDependency] to [targetDirectory].
+  Future<_ExternalPathDependency> copyTo({
+    required Directory targetDirectory,
+    CopyPath copyPath = io.copyPath,
+  }) async {
+    await copyPath(path, targetDirectory.path);
+    return _ExternalPathDependency(name: name, path: targetDirectory.path);
+  }
 }

--- a/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
+++ b/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
@@ -4,6 +4,7 @@ import 'package:dart_frog_prod_server_hooks/dart_frog_prod_server_hooks.dart';
 import 'package:io/io.dart' as io;
 import 'package:path/path.dart' as path;
 
+/// Signature of [io.copyPath].
 typedef CopyPath = Future<void> Function(String from, String to);
 
 Future<List<String>> createExternalPackagesFolder({

--- a/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
+++ b/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
@@ -2,12 +2,51 @@ import 'dart:io';
 
 import 'package:dart_frog_prod_server_hooks/dart_frog_prod_server_hooks.dart';
 import 'package:io/io.dart' as io;
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
+
+@visibleForTesting
+typedef CopyPath = Future<void> Function(String from, String to);
+
+/// {@template external_path_dependency}
+/// A path dependency that is not within the bundled Dart Frog project
+/// directory.
+///
+/// For example:
+/// ```yaml
+/// name: my_dart_frog_project
+/// dependencies:
+///   my_package:
+///     path: ../my_package
+/// ```
+/// {@endtemplate}
+class _ExternalPathDependency {
+  /// {@macro external_path_dependency}
+  const _ExternalPathDependency({
+    required this.name,
+    required this.path,
+  });
+
+  /// The name of the package.
+  final String name;
+
+  /// The path to the package.
+  final String path;
+
+  /// Copies the [_ExternalPathDependency] to [targetDirectory].
+  Future<_ExternalPathDependency> copyTo({
+    required Directory targetDirectory,
+    @visibleForTesting CopyPath copyPath = io.copyPath,
+  }) async {
+    await copyPath(path, targetDirectory.path);
+    return _ExternalPathDependency(name: name, path: targetDirectory.path);
+  }
+}
 
 Future<List<String>> createExternalPackagesFolder({
   required Directory projectDirectory,
   required Directory buildDirectory,
-  Future<void> Function(String from, String to) copyPath = io.copyPath,
+  @visibleForTesting CopyPath copyPath = io.copyPath,
 }) async {
   final pathResolver = path.context;
   final pubspecLock = await getPubspecLock(
@@ -21,55 +60,41 @@ Future<List<String>> createExternalPackagesFolder({
           sdk: (_) => null,
           hosted: (_) => null,
           git: (_) => null,
-          path: (d) => d.path,
+          path: (d) {
+            final isExternal = !pathResolver.isWithin('', d.path);
+            if (!isExternal) return null;
+
+            return _ExternalPathDependency(
+              name: pathResolver.basename(d.path),
+              path: path.join(projectDirectory.path, d.path),
+            );
+          },
         ),
       )
-      .whereType<String>()
-      .where((dependencyPath) {
-    return !pathResolver.isWithin('', dependencyPath);
-  }).toList();
+      .whereType<_ExternalPathDependency>()
+      .toList();
 
   if (externalPathDependencies.isEmpty) {
     return [];
   }
-  final mappedDependencies = externalPathDependencies
-      .map(
-    (dependencyPath) => (
-      pathResolver.basename(dependencyPath),
-      dependencyPath,
-    ),
-  )
-      .fold(<String, String>{}, (map, dependency) {
-    map[dependency.$1] = dependency.$2;
-    return map;
-  });
-
-  buildDirectory.createSync();
 
   final packagesDirectory = Directory(
     pathResolver.join(
       buildDirectory.path,
       '.dart_frog_path_dependencies',
     ),
-  )..createSync();
+  )..createSync(recursive: true);
 
-  final copiedPaths = <String>[];
-  for (final entry in mappedDependencies.entries) {
-    final from = pathResolver.join(projectDirectory.path, entry.value);
-    final to = pathResolver.join(packagesDirectory.path, entry.key);
-
-    await copyPath(from, to);
-    copiedPaths.add(
-      path.relative(to, from: buildDirectory.path),
-    );
-  }
-
-  final mappedPaths = mappedDependencies.map(
-    (key, value) => MapEntry(
-      key,
-      pathResolver.relative(
-        path.join(packagesDirectory.path, key),
-        from: buildDirectory.path,
+  final copiedExternalPathDependencies = await Future.wait(
+    externalPathDependencies.map(
+      (externalPathDependency) => externalPathDependency.copyTo(
+        copyPath: copyPath,
+        targetDirectory: Directory(
+          pathResolver.join(
+            packagesDirectory.path,
+            externalPathDependency.name,
+          ),
+        ),
       ),
     ),
   );
@@ -81,8 +106,17 @@ Future<List<String>> createExternalPackagesFolder({
     ),
   ).writeAsString('''
 dependency_overrides:
-${mappedPaths.entries.map((entry) => '  ${entry.key}:\n    path: ${entry.value}').join('\n')}
+${copiedExternalPathDependencies.map(
+    (dependency) {
+      final name = dependency.name;
+      final path =
+          pathResolver.relative(dependency.path, from: buildDirectory.path);
+      return '  $name:\n    path: $path';
+    },
+  ).join('\n')}
 ''');
 
-  return copiedPaths;
+  return copiedExternalPathDependencies
+      .map((dependency) => dependency.path)
+      .toList();
 }

--- a/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
+++ b/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
@@ -2,10 +2,8 @@ import 'dart:io';
 
 import 'package:dart_frog_prod_server_hooks/dart_frog_prod_server_hooks.dart';
 import 'package:io/io.dart' as io;
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
-@visibleForTesting
 typedef CopyPath = Future<void> Function(String from, String to);
 
 /// {@template external_path_dependency}
@@ -36,7 +34,7 @@ class _ExternalPathDependency {
   /// Copies the [_ExternalPathDependency] to [targetDirectory].
   Future<_ExternalPathDependency> copyTo({
     required Directory targetDirectory,
-    @visibleForTesting CopyPath copyPath = io.copyPath,
+    CopyPath copyPath = io.copyPath,
   }) async {
     await copyPath(path, targetDirectory.path);
     return _ExternalPathDependency(name: name, path: targetDirectory.path);
@@ -46,7 +44,7 @@ class _ExternalPathDependency {
 Future<List<String>> createExternalPackagesFolder({
   required Directory projectDirectory,
   required Directory buildDirectory,
-  @visibleForTesting CopyPath copyPath = io.copyPath,
+  CopyPath copyPath = io.copyPath,
 }) async {
   final pathResolver = path.context;
   final pubspecLock = await getPubspecLock(

--- a/bricks/dart_frog_prod_server/hooks/pubspec.yaml
+++ b/bricks/dart_frog_prod_server/hooks/pubspec.yaml
@@ -8,7 +8,6 @@ dependencies:
   dart_frog_gen: ^2.0.0
   io: ^1.0.3
   mason: ^0.1.0-dev.39
-  meta: ^1.11.0
   path: ^1.8.1
   pubspec_lock: ^3.0.2
 

--- a/bricks/dart_frog_prod_server/hooks/pubspec.yaml
+++ b/bricks/dart_frog_prod_server/hooks/pubspec.yaml
@@ -8,6 +8,7 @@ dependencies:
   dart_frog_gen: ^2.0.0
   io: ^1.0.3
   mason: ^0.1.0-dev.39
+  meta: ^1.11.0
   path: ^1.8.1
   pubspec_lock: ^3.0.2
 


### PR DESCRIPTION
## Status

**READY**

## Description

In preparation for #1243 

Changes:
- Refactors the logic by introducing `ExternalPathDependency` class
- Uses a type definition to avoid long type function signatures
- Copy directory paths in parallel with `Future.wait`


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
