### PR TITLE
fix(dart_frog_prod_server): stop assuming directory name is package name when bundling

### DIFF
--- a/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
+++ b/bricks/dart_frog_prod_server/hooks/lib/src/create_external_packages_folder.dart
@@ -29,7 +29,7 @@ Future<List<String>> createExternalPackagesFolder({
             if (!isExternal) return null;
 
             return _ExternalPathDependency(
-              name: pathResolver.basename(d.path),
+              name: p.package(),
               path: path.join(projectDirectory.path, d.path),
             );
           },

--- a/bricks/dart_frog_prod_server/hooks/test/pubspec_locks.dart
+++ b/bricks/dart_frog_prod_server/hooks/test/pubspec_locks.dart
@@ -6,6 +6,8 @@ library pubspec_locks;
 /// * A transitive dependency.
 /// * A direct main path dependency that is not a child of the project
 /// directory.
+/// * A direct main path dependency that is not a child of the project
+/// directory and has a different package name than the directory name.
 /// * A direct main dependency that is hosted.
 /// * A direct dev main dependency that is hosted.
 const fooPath = '''
@@ -22,6 +24,13 @@ packages:
     dependency: "direct main"
     description:
       path: "../../foo"
+      relative: true
+    source: path
+    version: "0.0.0"
+  second_foo:
+    dependency: "direct main"
+    description:
+      path: "../../foo2"
       relative: true
     source: path
     version: "0.0.0"

--- a/bricks/dart_frog_prod_server/hooks/test/src/create_external_packages_folder_test.dart
+++ b/bricks/dart_frog_prod_server/hooks/test/src/create_external_packages_folder_test.dart
@@ -25,14 +25,27 @@ void main() {
           },
         );
 
-        final from = path.join(projectDirectory.path, '../../foo');
-        final to = path.join(
+        final fooPackageDirectory =
+            path.join(projectDirectory.path, '../../foo');
+        final fooPackageDirectoryTarget = path.join(
           projectDirectory.path,
           'build',
           '.dart_frog_path_dependencies',
           'foo',
         );
-        expect(copyCalls, ['$from -> $to']);
+
+        final secondFooPackageDirectory =
+            path.join(projectDirectory.path, '../../foo2');
+        final secondFooPackageDirectoryTarget = path.join(
+          projectDirectory.path,
+          'build',
+          '.dart_frog_path_dependencies',
+          'second_foo',
+        );
+        expect(copyCalls, [
+          '$fooPackageDirectory -> $fooPackageDirectoryTarget',
+          '$secondFooPackageDirectory -> $secondFooPackageDirectoryTarget',
+        ]);
       },
     );
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Resolves #1243 

<details>

<summary> Demonstration </summary>

https://github.com/VeryGoodOpenSource/dart_frog/assets/44524995/f1d5d3be-5622-4477-a1bd-a0b9fa0dbbb6

</details>

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
