### PR TITLE
fix(dart_frog): allow access of `shelf.Message.context`

### DIFF
--- a/packages/dart_frog/lib/src/request.dart
+++ b/packages/dart_frog/lib/src/request.dart
@@ -100,6 +100,9 @@ class Request {
     return _request.context['shelf.io.connection_info']! as HttpConnectionInfo;
   }
 
+  /// Shelf context that can be used by shelf middleware and shelf handlers.
+  Map<String, Object> get shelfContext => _request.context;
+
   /// The requested url relative to the current handler path.
   Uri get url => _request.url;
 

--- a/packages/dart_frog/lib/src/response.dart
+++ b/packages/dart_frog/lib/src/response.dart
@@ -87,6 +87,9 @@ class Response {
   /// The HTTP status code of the response.
   int get statusCode => _response.statusCode;
 
+  /// Shelf context that can be used by shelf middleware and shelf handlers.
+  Map<String, Object> get shelfContext => _response.context;
+
   /// The HTTP headers with case-insensitive keys.
   /// The returned map is unmodifiable.
   Map<String, String> get headers => _response.headers;


### PR DESCRIPTION
## Status

READY

## Description

Allow access of `shelf.Message.context`, which is used by some shelf middleware and shelf handlers. 
closes #773.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
