### PR TITLE
docs: update Dart Frog CLI logo in Readme

### DIFF
--- a/packages/dart_frog_cli/README.md
+++ b/packages/dart_frog_cli/README.md
@@ -1,5 +1,5 @@
-[![Dart Frog Logo][logo_white]][dart_frog_link_dark]
-[![Dart Frog Logo][logo_black]][dart_frog_link_light]
+[<img src="https://raw.githubusercontent.com/VeryGoodOpenSource/dart_frog/main/docs/static/img/dart_frog_full_logo.svg" align="left" />](https://dartfrog.vgv.dev/)
+
 
 [![ci][ci_badge]][ci_link]
 [![coverage][coverage_badge]][ci_link]

--- a/packages/dart_frog_cli/README.md
+++ b/packages/dart_frog_cli/README.md
@@ -1,7 +1,5 @@
 [<img src="https://raw.githubusercontent.com/VeryGoodOpenSource/dart_frog/main/docs/static/img/dart_frog_full_logo.svg" align="left" />](https://dartfrog.vgv.dev/)
 
-### Dart Frog CLI
-
 <br clear="left"/>
 
 [![ci][ci_badge]][ci_link]

--- a/packages/dart_frog_cli/README.md
+++ b/packages/dart_frog_cli/README.md
@@ -1,5 +1,8 @@
 [<img src="https://raw.githubusercontent.com/VeryGoodOpenSource/dart_frog/main/docs/static/img/dart_frog_full_logo.svg" align="left" />](https://dartfrog.vgv.dev/)
 
+### Dart Frog CLI
+
+<br clear="left"/>
 
 [![ci][ci_badge]][ci_link]
 [![coverage][coverage_badge]][ci_link]


### PR DESCRIPTION
## Status

**READY**

## Description

Attempting to fix the issue with multiple Dart Frog logos showing up on Pub.dev. Just getting it to one logo for now. There will be a collision with GitHub in Dark Mode but not very concerned with that.

![CleanShot 2024-08-27 at 10 20 16](https://github.com/user-attachments/assets/e073ab6e-05ab-4031-9975-bf770c2a3c02)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
