### PR TITLE
ci: fix vscode publish action

### DIFF
--- a/.github/workflows/publish_dart_frog.yaml
+++ b/.github/workflows/publish_dart_frog.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "dart_frog-v*.*.*"
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish_dart_frog_auth.yaml
+++ b/.github/workflows/publish_dart_frog_auth.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "dart_frog_auth-v*.*.*"
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish_dart_frog_cli.yaml
+++ b/.github/workflows/publish_dart_frog_cli.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "dart_frog_cli-v*.*.*"
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish_dart_frog_gen.yaml
+++ b/.github/workflows/publish_dart_frog_gen.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "dart_frog_gen-v*.*.*"
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish_dart_frog_test.yaml
+++ b/.github/workflows/publish_dart_frog_test.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "dart_frog_test-v*.*.*"
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish_dart_frog_web_socket.yaml
+++ b/.github/workflows/publish_dart_frog_web_socket.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "dart_frog_web_socket-v*.*.*"
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish_extension_vscode.yaml
+++ b/.github/workflows/publish_extension_vscode.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "vscode-v*.*.*"
+  workflow_dispatch:
 
 jobs:
   publish_extension:
@@ -17,10 +18,12 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
 
-      - name: ⚙️ Setup Node
+      - name: 🎯 Setup Node.js (18.x)
         uses: actions/setup-node@v4
         with:
-          node-version: lts
+          node-version: 18.x
+          cache: "npm"
+          cache-dependency-path: extensions/vscode/package-lock.json
 
       - name: 🎉 Publish VS Code Extension
         run: |


### PR DESCRIPTION
## Status

**READY**

## Description

The VSCode publish action failed, https://github.com/VeryGoodOpenSource/dart_frog/actions/runs/11575428071. 

`Unable to find Node version 'lts' for platform linux and architecture x64.`

Copying over the setup node step that we run in the pipeline to have everything matched up.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
