### PR TITLE
chore(dart_frog_auth): 1.2.0

### DIFF
--- a/packages/dart_frog_auth/CHANGELOG.md
+++ b/packages/dart_frog_auth/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.2.0
+
+- feat(dart_frog_auth): add cookie authentication ([#1600](https://github.com/VeryGoodOpenSource/dart_frog/pull/1600))
+- refactor(dart_frog_auth): added argument name to the Applies typedef ([#1317](https://github.com/VeryGoodOpenSource/dart_frog/pull/1317))
+- fix: auth topics ([#949](https://github.com/VeryGoodOpenSource/dart_frog/pull/949))
+- chore(packages): bump very good analysis ([#983](https://github.com/VeryGoodOpenSource/dart_frog/pull/983))
+- chore(deps): bump very_good_analysis from 5.1.0 to 6.0.0 in /packages/dart_frog_auth ([#1430](https://github.com/VeryGoodOpenSource/dart_frog/pull/1430))
+
 # 1.1.0
 
 - feat: auth context api ([#879](https://github.com/VeryGoodOpenSource/dart_frog/pull/879))

--- a/packages/dart_frog_auth/CHANGELOG.md
+++ b/packages/dart_frog_auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.2.0
 
-- feat(dart_frog_auth): add cookie authentication ([#1600](https://github.com/VeryGoodOpenSource/dart_frog/pull/1600))
+- feat: add cookie authentication ([#1600](https://github.com/VeryGoodOpenSource/dart_frog/pull/1600))
 - refactor(dart_frog_auth): added argument name to the Applies typedef ([#1317](https://github.com/VeryGoodOpenSource/dart_frog/pull/1317))
 - fix: auth topics ([#949](https://github.com/VeryGoodOpenSource/dart_frog/pull/949))
 - chore(packages): bump very good analysis ([#983](https://github.com/VeryGoodOpenSource/dart_frog/pull/983))

--- a/packages/dart_frog_auth/CHANGELOG.md
+++ b/packages/dart_frog_auth/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.2.0
 
 - feat: add cookie authentication ([#1600](https://github.com/VeryGoodOpenSource/dart_frog/pull/1600))
-- refactor(dart_frog_auth): added argument name to the Applies typedef ([#1317](https://github.com/VeryGoodOpenSource/dart_frog/pull/1317))
+- refactor: added argument name to the Applies typedef ([#1317](https://github.com/VeryGoodOpenSource/dart_frog/pull/1317))
 - fix: auth topics ([#949](https://github.com/VeryGoodOpenSource/dart_frog/pull/949))
 - chore(packages): bump very good analysis ([#983](https://github.com/VeryGoodOpenSource/dart_frog/pull/983))
 - chore(deps): bump very_good_analysis from 5.1.0 to 6.0.0 in /packages/dart_frog_auth ([#1430](https://github.com/VeryGoodOpenSource/dart_frog/pull/1430))

--- a/packages/dart_frog_auth/pubspec.yaml
+++ b/packages/dart_frog_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_frog_auth
 description: Header authentication based middlewares for Dart Frog. Built by Very Good Ventures.
-version: 1.1.0
+version: 1.2.0
 homepage: https://dartfrog.vgv.dev
 repository: https://github.com/VeryGoodOpenSource/dart_frog
 issue_tracker: https://github.com/VeryGoodOpenSource/dart_frog/issues


### PR DESCRIPTION
## Status

**READY**

## Description

Closes #1617. Gets 1.2.0 release for Dart Frog Auth completed.

Note: Docs site updates have been removed from this changelog.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
