### PR TITLE
chore(dart_frog): v1.2.0

### DIFF
--- a/packages/dart_frog/CHANGELOG.md
+++ b/packages/dart_frog/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.0
+
+- chore(deps): bump very_good_analysis from 5.1.0 to 6.0.0 in /packages/dart_frog ([#1432](https://github.com/VeryGoodOpenSource/dart_frog/pull/1432))
+- chore(deps): bump mime from 1.0.6 to 2.0.0 in /packages/dart_frog ([#1528](https://github.com/VeryGoodOpenSource/dart_frog/pull/1528))
+
 # 1.1.0
 
 - feat: support reuse of nested router ([#393](https://github.com/VeryGoodOpenSource/dart_frog/pull/393))

--- a/packages/dart_frog/lib/src/response.dart
+++ b/packages/dart_frog/lib/src/response.dart
@@ -95,7 +95,7 @@ class Response {
           encoding: encoding,
         );
 
-  /// A shelf.Response.context key used to determine if if the
+  /// A `shelf.Response.context` key used to determine if if the
   /// [HttpResponse.bufferOutput] should be enabled or disabled.
   ///
   /// See also:

--- a/packages/dart_frog/lib/src/response.dart
+++ b/packages/dart_frog/lib/src/response.dart
@@ -95,7 +95,7 @@ class Response {
           encoding: encoding,
         );
 
-  /// A [shelf.Response.context] key used to determine if if the
+  /// A shelf.Response.context key used to determine if if the
   /// [HttpResponse.bufferOutput] should be enabled or disabled.
   ///
   /// See also:

--- a/packages/dart_frog/pubspec.yaml
+++ b/packages/dart_frog/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_frog
 description: A fast, minimalistic backend framework for Dart built by Very Good Ventures.
-version: 1.1.0
+version: 1.2.0
 homepage: https://dartfrog.vgv.dev
 repository: https://github.com/VeryGoodOpenSource/dart_frog
 issue_tracker: https://github.com/VeryGoodOpenSource/dart_frog/issues


### PR DESCRIPTION
## Status

**READY**

## Description

Closes #1616. Get the 1.2.0 release for the main dart_frog package released.

Note: Docs updates have been removed from the changelog.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
