### PR TITLE
chore(dart_frog_cli): 1.2.4

### DIFF
--- a/packages/dart_frog_cli/CHANGELOG.md
+++ b/packages/dart_frog_cli/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.2.4
+
+- chore(deps): tighten dependencies ([#1489](https://github.com/VeryGoodOpenSource/dart_frog/pull/1489))
+- chore(deps): bump mason from 0.1.0-dev.58 to 0.1.0-dev.59 in /packages/dart_frog_cli ([#1494](https://github.com/VeryGoodOpenSource/dart_frog/pull/1494))
+- chore(deps): bump pub_updater from 0.4.0 to 0.5.0 in /packages/dart_frog_cli ([#1495](https://github.com/VeryGoodOpenSource/dart_frog/pull/1495))
+- chore(deps): bump mason from 0.1.0-dev.59 to 0.1.0-dev.60 in /packages/dart_frog_cli ([#1504](https://github.com/VeryGoodOpenSource/dart_frog/pull/1504))
+- chore(deps): bump mason from 0.1.0-dev.60 to 0.1.0 in /packages/dart_frog_cli ([#1602](https://github.com/VeryGoodOpenSource/dart_frog/pull/1602))
+
 # 1.2.3
 
 - chore: bump cli_completion from 0.4.0 to 0.5.0 in /packages/dart_frog_cli ([#1288](https://github.com/VeryGoodOpenSource/dart_frog/pull/1288))

--- a/packages/dart_frog_cli/lib/src/version.dart
+++ b/packages/dart_frog_cli/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.2.3';
+const packageVersion = '1.2.4';

--- a/packages/dart_frog_cli/pubspec.yaml
+++ b/packages/dart_frog_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_frog_cli
 description: The official command line interface for Dart Frog. Built by Very Good Ventures.
-version: 1.2.3
+version: 1.2.4
 homepage: https://dartfrog.vgv.dev
 repository: https://github.com/VeryGoodOpenSource/dart_frog
 issue_tracker: https://github.com/VeryGoodOpenSource/dart_frog/issues


### PR DESCRIPTION
## Status

**READY/IN DEVELOPMENT/HOLD**

## Description

Closes #1615. Get's the dart_frog_cli 1.2.4 release ready.

Note: docs updates have been removed from the changelog

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
