### PR TITLE
fix: update mason version in cli

### DIFF
--- a/packages/dart_frog_cli/pubspec.yaml
+++ b/packages/dart_frog_cli/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   cli_completion: ^0.5.1
   dart_frog_gen: ^2.0.0
   equatable: ^2.0.5
-  mason: 0.1.0
+  mason: ^0.1.0
   meta: ^1.15.0
   path: ^1.9.0
   pub_updater: ^0.5.0


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes #1621. Updates `mason` for the cli to resolve the right way and pub doesn't complain.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
