### PR TITLE
feat(dart_frog_auth): add custom unauthenticated responses to all aut…

### DIFF
--- a/packages/dart_frog_auth/lib/src/dart_frog_auth.dart
+++ b/packages/dart_frog_auth/lib/src/dart_frog_auth.dart
@@ -72,6 +72,7 @@ Middleware basicAuthentication<T extends Object>({
     String password,
   )? authenticator,
   Applies applies = _defaultApplies,
+  Handler? unauthenticatedResponse,
 }) {
   assert(
     userFromCredentials != null || authenticator != null,
@@ -102,7 +103,8 @@ Middleware basicAuthentication<T extends Object>({
           }
         }
 
-        return Response(statusCode: HttpStatus.unauthorized);
+        return unauthenticatedResponse?.call(context) ??
+            Response(statusCode: HttpStatus.unauthorized);
       };
 }
 
@@ -134,6 +136,7 @@ Middleware bearerAuthentication<T extends Object>({
   Future<T?> Function(String token)? userFromToken,
   Future<T?> Function(RequestContext context, String token)? authenticator,
   Applies applies = _defaultApplies,
+  Handler? unauthenticatedResponse,
 }) {
   assert(
     userFromToken != null || authenticator != null,
@@ -162,7 +165,8 @@ Middleware bearerAuthentication<T extends Object>({
           }
         }
 
-        return Response(statusCode: HttpStatus.unauthorized);
+        return unauthenticatedResponse?.call(context) ??
+            Response(statusCode: HttpStatus.unauthorized);
       };
 }
 
@@ -195,6 +199,7 @@ Middleware cookieAuthentication<T extends Object>({
     Map<String, String> cookies,
   ) authenticator,
   Applies applies = _defaultApplies,
+  Handler? unauthenticatedResponse,
 }) {
   return (handler) => (context) async {
         if (!await applies(context)) {
@@ -210,6 +215,7 @@ Middleware cookieAuthentication<T extends Object>({
           }
         }
 
-        return Response(statusCode: HttpStatus.unauthorized);
+        return unauthenticatedResponse?.call(context) ??
+            Response(statusCode: HttpStatus.unauthorized);
       };
 }

--- a/packages/dart_frog_auth/test/src/dart_frog_auth_test.dart
+++ b/packages/dart_frog_auth/test/src/dart_frog_auth_test.dart
@@ -11,6 +11,8 @@ class _MockRequestContext extends Mock implements RequestContext {}
 
 class _MockRequest extends Mock implements Request {}
 
+class _MockResponse extends Mock implements Response {}
+
 class _User {
   const _User(this.id);
   final String id;
@@ -84,6 +86,60 @@ void main() {
           );
         },
       );
+
+      group('and custom unauthenticated response is provided', () {
+        test(
+          'returns custom response when Authorization header is not present',
+          () async {
+            final response = _MockResponse();
+            final middleware = basicAuthentication<_User>(
+              userFromCredentials: (_, __) async => user,
+              unauthenticatedResponse: (context) => response,
+            );
+            expect(
+              await middleware((_) async => Response())(context),
+              equals(response),
+            );
+          },
+        );
+
+        test(
+          'returns custom response when Authorization header is present but '
+          'invalid',
+          () async {
+            final response = _MockResponse();
+            when(() => request.headers)
+                .thenReturn({'Authorization': 'not valid'});
+            final middleware = basicAuthentication<_User>(
+              userFromCredentials: (_, __) async => user,
+              unauthenticatedResponse: (context) => response,
+            );
+            expect(
+              await middleware((_) async => Response())(context),
+              equals(response),
+            );
+          },
+        );
+
+        test(
+          'returns custom response when Authorization header is present and '
+          'valid but no user is returned',
+          () async {
+            final response = _MockResponse();
+            when(() => request.headers).thenReturn({
+              'Authorization': 'Bearer 1234',
+            });
+            final middleware = basicAuthentication<_User>(
+              userFromCredentials: (_, __) async => null,
+              unauthenticatedResponse: (context) => response,
+            );
+            expect(
+              await middleware((_) async => Response())(context),
+              equals(response),
+            );
+          },
+        );
+      });
 
       test(
         'sets the user when everything is valid',
@@ -187,6 +243,60 @@ void main() {
           );
         },
       );
+
+      group('and custom unauthenticated response is provided', () {
+        test(
+          'returns custom response when Authorization header is not present',
+          () async {
+            final response = _MockResponse();
+            final middleware = basicAuthentication<_User>(
+              authenticator: (_, __, ___) async => user,
+              unauthenticatedResponse: (context) => response,
+            );
+            expect(
+              await middleware((_) async => Response())(context),
+              equals(response),
+            );
+          },
+        );
+
+        test(
+          'returns custom response when Authorization header is present but '
+          'invalid',
+          () async {
+            final response = _MockResponse();
+            when(() => request.headers)
+                .thenReturn({'Authorization': 'not valid'});
+            final middleware = basicAuthentication<_User>(
+              authenticator: (_, __, ___) async => user,
+              unauthenticatedResponse: (context) => response,
+            );
+            expect(
+              await middleware((_) async => Response())(context),
+              equals(response),
+            );
+          },
+        );
+
+        test(
+          'returns custom response when Authorization header is present and '
+          'valid but no user is returned',
+          () async {
+            final response = _MockResponse();
+            when(() => request.headers).thenReturn({
+              'Authorization': 'Basic dXNlcjpwYXNz',
+            });
+            final middleware = basicAuthentication<_User>(
+              authenticator: (_, __, ___) async => null,
+              unauthenticatedResponse: (context) => response,
+            );
+            expect(
+              await middleware((_) async => Response())(context),
+              equals(response),
+            );
+          },
+        );
+      });
 
       test(
         'sets the user when everything is valid',
@@ -305,6 +415,60 @@ void main() {
         },
       );
 
+      group('and custom unauthenticated response is provided', () {
+        test(
+          'returns custom response when Authorization header is not present',
+          () async {
+            final response = _MockResponse();
+            final middleware = bearerAuthentication<_User>(
+              userFromToken: (_) async => user,
+              unauthenticatedResponse: (context) => response,
+            );
+            expect(
+              await middleware((_) async => Response())(context),
+              equals(response),
+            );
+          },
+        );
+
+        test(
+          'returns custom response when Authorization header is present but '
+          'invalid',
+          () async {
+            final response = _MockResponse();
+            when(() => request.headers)
+                .thenReturn({'Authorization': 'not valid'});
+            final middleware = bearerAuthentication<_User>(
+              userFromToken: (_) async => user,
+              unauthenticatedResponse: (context) => response,
+            );
+            expect(
+              await middleware((_) async => Response())(context),
+              equals(response),
+            );
+          },
+        );
+
+        test(
+          'returns custom response when Authorization header is present and '
+          'valid but no user is returned',
+          () async {
+            final response = _MockResponse();
+            when(() => request.headers).thenReturn({
+              'Authorization': 'Bearer 1234',
+            });
+            final middleware = bearerAuthentication<_User>(
+              userFromToken: (_) async => null,
+              unauthenticatedResponse: (context) => response,
+            );
+            expect(
+              await middleware((_) async => Response())(context),
+              equals(response),
+            );
+          },
+        );
+      });
+
       test(
         'sets the user when everything is valid',
         () async {
@@ -408,6 +572,60 @@ void main() {
         },
       );
 
+      group('and custom unauthenticated response is provided', () {
+        test(
+          'returns custom response when Authorization header is not present',
+          () async {
+            final response = _MockResponse();
+            final middleware = bearerAuthentication<_User>(
+              authenticator: (_, __) async => user,
+              unauthenticatedResponse: (context) => response,
+            );
+            expect(
+              await middleware((_) async => Response())(context),
+              equals(response),
+            );
+          },
+        );
+
+        test(
+          'returns custom response when Authorization header is present but '
+          'invalid',
+          () async {
+            final response = _MockResponse();
+            when(() => request.headers)
+                .thenReturn({'Authorization': 'not valid'});
+            final middleware = bearerAuthentication<_User>(
+              authenticator: (_, __) async => user,
+              unauthenticatedResponse: (context) => response,
+            );
+            expect(
+              await middleware((_) async => Response())(context),
+              equals(response),
+            );
+          },
+        );
+
+        test(
+          'returns custom response when Authorization header is present and '
+          'valid but no user is returned',
+          () async {
+            final response = _MockResponse();
+            when(() => request.headers).thenReturn({
+              'Authorization': 'Bearer 1234',
+            });
+            final middleware = bearerAuthentication<_User>(
+              authenticator: (_, __) async => null,
+              unauthenticatedResponse: (context) => response,
+            );
+            expect(
+              await middleware((_) async => Response())(context),
+              equals(response),
+            );
+          },
+        );
+      });
+
       test(
         'sets the user when everything is valid',
         () async {
@@ -501,6 +719,40 @@ void main() {
         );
       },
     );
+
+    group('and custom unauthenticated response is provided', () {
+      test(
+        'returns custom response when Cookie header is not present',
+        () async {
+          final response = _MockResponse();
+          final middleware = cookieAuthentication<_User>(
+            authenticator: (_, __) async => user,
+            unauthenticatedResponse: (context) => response,
+          );
+          expect(
+            await middleware((_) async => Response())(context),
+            equals(response),
+          );
+        },
+      );
+
+      test(
+        'returns custom response when Cookie header is present '
+        'but no user is returned',
+        () async {
+          final response = _MockResponse();
+          when(() => request.headers).thenReturn({'Cookie': 'session=abc123'});
+          final middleware = cookieAuthentication<_User>(
+            authenticator: (_, __) async => null,
+            unauthenticatedResponse: (context) => response,
+          );
+          expect(
+            await middleware((_) async => Response())(context),
+            equals(response),
+          );
+        },
+      );
+    });
 
     test(
       'sets the user when everything is valid',


### PR DESCRIPTION
…h middleware

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Closes #1631. Adds an optional `unauthenticatedResponse` to all auth middleware which enables users to customize the response returned when a user is unauthenticated. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
