### PR TITLE
feat(dart_frog): support multiple values/files per form field

### DIFF
--- a/docs/src/content/docs/basics/routes.mdx
+++ b/docs/src/content/docs/basics/routes.mdx
@@ -282,7 +282,7 @@ Future<Response> onRequest(RequestContext context) async {
   final formData = await request.formData();
 
   // Retrieve an uploaded file.
-  final photo = formData.files['photo'];
+  final photo = formData.files['photo']?.first;
 
   if (photo == null || photo.contentType.mimeType != contentTypePng.mimeType) {
     return Response(statusCode: HttpStatus.badRequest);

--- a/examples/kitchen_sink/routes/photos/upload.dart
+++ b/examples/kitchen_sink/routes/photos/upload.dart
@@ -6,7 +6,7 @@ final contentTypePng = ContentType('image', 'png');
 
 Future<Response> onRequest(RequestContext context) async {
   final formData = await context.request.formData();
-  final photo = formData.files['photo'];
+  final photo = formData.files['photo']?.first;
 
   if (photo == null || photo.contentType.mimeType != contentTypePng.mimeType) {
     return Response(statusCode: HttpStatus.badRequest);

--- a/examples/kitchen_sink/test/routes/photos/upload_test.dart
+++ b/examples/kitchen_sink/test/routes/photos/upload_test.dart
@@ -23,11 +23,13 @@ void main() {
       final formData = FormData(
         fields: {},
         files: {
-          'photo': UploadedFile(
-            'file.txt',
-            ContentType.text,
-            Stream.fromIterable([[]]),
-          ),
+          'photo': [
+            UploadedFile(
+              'file.txt',
+              ContentType.text,
+              Stream.fromIterable([[]]),
+            ),
+          ],
         },
       );
       when(request.formData).thenAnswer((_) async => formData);
@@ -44,11 +46,13 @@ void main() {
       final formData = FormData(
         fields: {},
         files: {
-          'photo': UploadedFile(
-            'picture.png',
-            ContentType('image', 'png'),
-            Stream.fromIterable([[]]),
-          ),
+          'photo': [
+            UploadedFile(
+              'picture.png',
+              ContentType('image', 'png'),
+              Stream.fromIterable([[]]),
+            ),
+          ],
         },
       );
       when(request.formData).thenAnswer((_) async => formData);

--- a/examples/kitchen_sink/test/routes/projects/index_test.dart
+++ b/examples/kitchen_sink/test/routes/projects/index_test.dart
@@ -56,9 +56,9 @@ void main() {
         response.json(),
         completion(
           equals({
-            'project_configuration': const <String, String>{
-              'name': 'my_app',
-              'version': '3.3.8',
+            'project_configuration': const <String, List<String>>{
+              'name': ['my_app'],
+              'version': ['3.3.8'],
             },
           }),
         ),

--- a/packages/dart_frog/lib/src/body_parsers/form_data.dart
+++ b/packages/dart_frog/lib/src/body_parsers/form_data.dart
@@ -61,7 +61,11 @@ bool _isMultipartFormData(ContentType? contentType) {
 }
 
 FormData _extractFormUrlEncodedFormData({required String body}) {
-  return FormData(fields: Uri.splitQueryString(body), files: {});
+  final query = Uri.splitQueryString(body);
+  final fields = <String, List<String>>{};
+
+  query.forEach((k, v) => fields.putIfAbsent(k, () => []).add(v));
+  return FormData(fields: fields, files: {});
 }
 
 final _keyValueRegexp = RegExp('(?:(?<key>[a-zA-Z0-9-_]+)="(?<value>.*?)";*)+');
@@ -75,8 +79,8 @@ Future<FormData> _extractMultipartFormData({
   final boundary = mediaType.parameters['boundary'];
   final transformer = MimeMultipartTransformer(boundary!);
 
-  final fields = <String, String>{};
-  final files = <String, UploadedFile>{};
+  final fields = <String, List<String>>{};
+  final files = <String, List<UploadedFile>>{};
 
   await for (final part in transformer.bind(bytes)) {
     final contentDisposition = part.headers['content-disposition'];
@@ -93,14 +97,16 @@ Future<FormData> _extractMultipartFormData({
     final fileName = values['filename'];
 
     if (fileName != null) {
-      files[name] = UploadedFile(
-        fileName,
-        ContentType.parse(part.headers['content-type'] ?? 'text/plain'),
-        part,
-      );
+      files.putIfAbsent(name, () => []).add(
+            UploadedFile(
+              fileName,
+              ContentType.parse(part.headers['content-type'] ?? 'text/plain'),
+              part,
+            ),
+          );
     } else {
       final bytes = (await part.toList()).fold(<int>[], (p, e) => p..addAll(e));
-      fields[name] = utf8.decode(bytes);
+      fields.putIfAbsent(name, () => []).add(utf8.decode(bytes));
     }
   }
 
@@ -110,27 +116,27 @@ Future<FormData> _extractMultipartFormData({
 /// {@template form_data}
 /// The fields and files of received form data request.
 /// {@endtemplate}
-class FormData with MapMixin<String, String> {
+class FormData with MapMixin<String, List<String>> {
   /// {@macro form_data}
   const FormData({
-    required Map<String, String> fields,
-    required Map<String, UploadedFile> files,
+    required Map<String, List<String>> fields,
+    required Map<String, List<UploadedFile>> files,
   })  : _fields = fields,
         _files = files;
 
-  final Map<String, String> _fields;
+  final Map<String, List<String>> _fields;
 
-  final Map<String, UploadedFile> _files;
+  final Map<String, List<UploadedFile>> _files;
 
   /// The fields that were submitted in the form.
-  Map<String, String> get fields => Map.unmodifiable(_fields);
+  Map<String, List<String>> get fields => Map.unmodifiable(_fields);
 
   /// The files that were uploaded in the form.
-  Map<String, UploadedFile> get files => Map.unmodifiable(_files);
+  Map<String, List<UploadedFile>> get files => Map.unmodifiable(_files);
 
   @override
   @Deprecated('Use `fields[key]` to retrieve values')
-  String? operator [](Object? key) => _fields[key] ?? _files[key]?.toString();
+  List<String>? operator [](Object? key) => _fields[key];
 
   @override
   @Deprecated('Use `fields.keys` to retrieve field keys')
@@ -138,13 +144,13 @@ class FormData with MapMixin<String, String> {
 
   @override
   @Deprecated('Use `fields.values` to retrieve field values')
-  Iterable<String> get values => _fields.values;
+  Iterable<List<String>> get values => _fields.values;
 
   @override
   @Deprecated(
     'FormData should be immutable, in the future this will thrown an error',
   )
-  void operator []=(String key, String value) => _fields[key] = value;
+  void operator []=(String key, List<String> value) => _fields[key] = value;
 
   @override
   @Deprecated(
@@ -156,7 +162,7 @@ class FormData with MapMixin<String, String> {
   @Deprecated(
     'FormData should be immutable, in the future this will thrown an error',
   )
-  String? remove(Object? key) => _fields.remove(key);
+  List<String>? remove(Object? key) => _fields.remove(key);
 }
 
 /// {@template uploaded_file}

--- a/packages/dart_frog/test/src/body_parsers/form_data_test.dart
+++ b/packages/dart_frog/test/src/body_parsers/form_data_test.dart
@@ -66,7 +66,12 @@ Actual MIME type: "application/json"
         bytes: () async* {},
       );
 
-      expect(formData.fields, equals({'foo': 'bar'}));
+      expect(
+        formData.fields,
+        equals({
+          'foo': ['bar'],
+        }),
+      );
       expect(formData.files, isEmpty);
     });
 
@@ -81,7 +86,13 @@ Actual MIME type: "application/json"
         bytes: () async* {},
       );
 
-      expect(formData.fields, equals({'foo': 'bar', 'bar': 'baz'}));
+      expect(
+        formData.fields,
+        equals({
+          'foo': ['bar'],
+          'bar': ['baz'],
+        }),
+      );
       expect(formData.files, isEmpty);
     });
 
@@ -101,7 +112,12 @@ Actual MIME type: "application/json"
           },
         );
 
-        expect(formData.fields, equals({'foo': 'bar'}));
+        expect(
+          formData.fields,
+          equals({
+            'foo': ['bar'],
+          }),
+        );
         expect(formData.files, isEmpty);
       });
 
@@ -130,11 +146,13 @@ Actual MIME type: "application/json"
         expect(
           formData.files,
           equals({
-            'my_file': isUploadedFile(
-              'my_file.txt',
-              ContentType.text,
-              'file content',
-            ),
+            'my_file': [
+              isUploadedFile(
+                'my_file.txt',
+                ContentType.text,
+                'file content',
+              ),
+            ],
           }),
         );
       });
@@ -168,20 +186,30 @@ Actual MIME type: "application/json"
           },
         );
 
-        expect(formData.fields, equals({'foo': 'bar', 'bar': 'baz'}));
+        expect(
+          formData.fields,
+          equals({
+            'foo': ['bar'],
+            'bar': ['baz'],
+          }),
+        );
         expect(
           formData.files,
           equals({
-            'my_file': isUploadedFile(
-              'my_file.txt',
-              ContentType.text,
-              'file content',
-            ),
-            'my_other_file': isUploadedFile(
-              'my_other_file.txt',
-              ContentType.text,
-              'file content',
-            ),
+            'my_file': [
+              isUploadedFile(
+                'my_file.txt',
+                ContentType.text,
+                'file content',
+              ),
+            ],
+            'my_other_file': [
+              isUploadedFile(
+                'my_other_file.txt',
+                ContentType.text,
+                'file content',
+              ),
+            ],
           }),
         );
       });
@@ -189,23 +217,54 @@ Actual MIME type: "application/json"
   });
 
   group('$FormData', () {
-    test('is backwards compatible with a Map<String, String>', () {
+    test('supports Map<String, List<String>> access', () {
       final formData = FormData(
-        fields: {'foo': 'bar', 'bar': 'baz'},
+        fields: {
+          'foo': ['bar'],
+          'bar': ['baz'],
+        },
         files: {},
       );
 
-      expect(formData['foo'], equals('bar'));
+      expect(formData['foo'], equals(['bar']));
       expect(formData.keys, equals(['foo', 'bar']));
-      expect(formData.values, equals(['bar', 'baz']));
+      expect(
+        formData.values,
+        equals([
+          ['bar'],
+          ['baz'],
+        ]),
+      );
 
       formData.remove('bar');
-      expect(formData, equals({'foo': 'bar'}));
-      expect(formData.fields, equals({'foo': 'bar'}));
+      expect(
+        formData,
+        equals({
+          'foo': ['bar'],
+        }),
+      );
+      expect(
+        formData.fields,
+        equals({
+          'foo': ['bar'],
+        }),
+      );
 
-      formData['bar'] = 'baz';
-      expect(formData, equals({'foo': 'bar', 'bar': 'baz'}));
-      expect(formData.fields, equals({'foo': 'bar', 'bar': 'baz'}));
+      formData['bar'] = ['baz'];
+      expect(
+        formData,
+        equals({
+          'foo': ['bar'],
+          'bar': ['baz'],
+        }),
+      );
+      expect(
+        formData.fields,
+        equals({
+          'foo': ['bar'],
+          'bar': ['baz'],
+        }),
+      );
 
       formData.clear();
       expect(formData, equals(isEmpty));

--- a/packages/dart_frog/test/src/request_test.dart
+++ b/packages/dart_frog/test/src/request_test.dart
@@ -204,7 +204,14 @@ ${HttpMethod.values.map((m) => m.value.toUpperCase()).join(', ')}.'''),
           headers: contentTypeFormUrlEncoded,
           body: 'foo=bar',
         );
-        expect(request.formData(), completion(equals({'foo': 'bar'})));
+        expect(
+          request.formData(),
+          completion(
+            equals({
+              'foo': ['bar'],
+            }),
+          ),
+        );
       });
 
       test('has correct data (multiple key/value pairs)', () async {
@@ -215,7 +222,12 @@ ${HttpMethod.values.map((m) => m.value.toUpperCase()).join(', ')}.'''),
         );
         expect(
           request.formData(),
-          completion(equals({'foo': 'bar', 'bar': 'baz'})),
+          completion(
+            equals({
+              'foo': ['bar'],
+              'bar': ['baz'],
+            }),
+          ),
         );
       });
     });

--- a/packages/dart_frog/test/src/response_test.dart
+++ b/packages/dart_frog/test/src/response_test.dart
@@ -170,7 +170,14 @@ void main() {
           headers: contentTypeFormUrlEncoded,
           body: 'foo=bar',
         );
-        expect(response.formData(), completion(equals({'foo': 'bar'})));
+        expect(
+          response.formData(),
+          completion(
+            equals({
+              'foo': ['bar'],
+            }),
+          ),
+        );
       });
 
       test('has correct data (multiple key/value pairs)', () async {
@@ -180,7 +187,12 @@ void main() {
         );
         expect(
           response.formData(),
-          completion(equals({'foo': 'bar', 'bar': 'baz'})),
+          completion(
+            equals({
+              'foo': ['bar'],
+              'bar': ['baz'],
+            }),
+          ),
         );
       });
     });


### PR DESCRIPTION
This PR aims to accommodate [RFC 7578 Section 4.3](https://datatracker.ietf.org/doc/html/rfc7578#section-4.3), which specifies that multiple files can be uploaded under a single form field.

## Status

**READY**

## Description

- Refactor `FormData` to store files as `List<UploadedFile>` per field.
- Refactor form data parsing to support multiple values/files per field.

### Breaking change
`FormData` no longer supports accessing values/files directly via a single key-value pair. The values/files for each field are now returned as lists.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
