### PR TITLE
docs: fix middleware testing example

### DIFF
--- a/docs/src/content/docs/basics/testing.mdx
+++ b/docs/src/content/docs/basics/testing.mdx
@@ -133,9 +133,11 @@ We can unit test this piece of middleware in isolation using `package:test` and
 `package:mocktail` just like before.
 
 To test this, we need to import our middleware, create a mock `RequestContext`
-using `package:mocktail`, apply our middleware to a dummy handler, and invoke
-the handler with a mock request context. Then, we can assert that the simple
-handler we applied the middleware to had access to the provided value.
+using `package:mocktail`, stub `context.provide` (which the `provider` middleware
+calls under the hood to inject the value), apply our middleware to a dummy
+handler, and invoke the handler with the mock request context. Then, we can
+capture the value the middleware provided and assert that it matches what we
+expect.
 
 ```dart
 import 'package:dart_frog/dart_frog.dart';
@@ -150,22 +152,20 @@ void main() {
   group('middleware', () {
     test('provides greeting', () async {
       // Arrange
-      String? greeting;
-      final handler = middleware(
-        (context) {
-          greeting = context.read<String>();
-          return Response(body: '');
-        },
-      );
+      final handler = middleware((_) => Response(body: ''));
       final request = Request.get(Uri.parse('http://localhost/'));
       final context = _MockRequestContext();
       when(() => context.request).thenReturn(request);
+      when(() => context.provide<String>(any())).thenReturn(context);
 
       // Act
       await handler(context);
 
       // Assert
-      expect(greeting, equals('Hello World'));
+      final create = verify(() => context.provide<String>(captureAny()))
+          .captured
+          .single as String Function();
+      expect(create(), equals('Hello World'));
     });
   });
 }
@@ -173,7 +173,9 @@ void main() {
 
 :::note
 
-We are stubbing the `context.request` with a real `Request` object so that the
-`provider` is able to inject the value.
+The `provider` middleware injects values by calling `context.provide`, so we
+stub it to return the mocked `context` and capture the callback it was given.
+Invoking that captured callback lets us assert the value the middleware
+provides. (We also stub `context.request` with a real `Request` object.)
 
 :::


### PR DESCRIPTION
docs: fix broken middleware testing example

## What was broken

The middleware test on the [Testing](https://dart-frog.dev/basics/testing/#middleware)
page does not compile-and-pass as written. Running it throws:

```
type 'Null' is not a subtype of type 'RequestContext'
  test/routes/_middleware_test.dart 7:7     _MockRequestContext.provide
  package:dart_frog/src/provider.dart 8:41  provider.<fn>.<fn>
  test/routes/_middleware_test.dart 25:20   main.<fn>.<fn>
```

The `provider` middleware injects its value by calling `context.provide(...)`:

```dart
// packages/dart_frog/lib/src/provider.dart
return (context) => handler(context.provide(() => create(context)));
```

`RequestContext.provide` returns a (non-nullable) `RequestContext`. The example
only stubbed `context.request`, never `context.provide`, so on the mock context
`provide` returned `null`. That `null` is then passed straight into the wrapped
handler, which expects a `RequestContext`, producing the type error above. The
old example's `context.read<String>()` line is never reached.

## The fix

Stub `context.provide<String>` to return the mocked context, then capture the
callback the `provider` handed it and assert that invoking it yields the expected
value. This is the same pattern the repo's own examples already use
(`examples/kitchen_sink/test/routes/_middleware_test.dart`,
`examples/counter/test/routes/_middleware_test.dart`), so the docs now match the
maintained code.

```dart
// Arrange
final handler = middleware((_) => Response(body: ''));
final request = Request.get(Uri.parse('http://localhost/'));
final context = _MockRequestContext();
when(() => context.request).thenReturn(request);
when(() => context.provide<String>(any())).thenReturn(context);

// Act
await handler(context);

// Assert
final create = verify(() => context.provide<String>(captureAny()))
    .captured
    .single as String Function();
expect(create(), equals('Hello World'));
```

The surrounding prose and the `:::note` were updated to explain the
`context.provide` stub, which is the crux of the fix.

## Evidence

Reproduced against `packages/dart_frog` (v1.2.6) with a scratch project using the
verbatim documented example.

Before (documented example, verbatim):

```
00:00 +0 -1: middleware provides greeting [E]
  type 'Null' is not a subtype of type 'RequestContext'
  test/routes/_middleware_test.dart 7:7     _MockRequestContext.provide
  package:dart_frog/src/provider.dart 8:41  provider.<fn>.<fn>
00:00 +0 -1: Some tests failed.
```

After (corrected example):

```
00:00 +1: All tests passed!
```

The corrected test is not a tautology: changing the middleware to provide a
different value (e.g. `'Goodbye'`) makes it fail with
`Expected: 'Hello World' Actual: 'Goodbye'`, confirming it exercises the
middleware's provided value rather than a hard-coded stub.

This fixes the broken example reported in #1963.

Note: #1963 also raises a broader request (a public `RequestContext` constructor / mock-free testing). This PR only corrects the documented example and intentionally does **not** close that discussion — so #1963 can stay open for the API question.

