### PR TITLE
fix(dart_frog_gen): order route mounts by specificity

### DIFF
--- a/packages/dart_frog_gen/lib/src/build_route_configuration.dart
+++ b/packages/dart_frog_gen/lib/src/build_route_configuration.dart
@@ -30,6 +30,12 @@ RouteConfiguration buildRouteConfiguration(Directory directory) {
   ];
   final routes = <RouteFile>[];
   final rogueRoutes = <RouteFile>[];
+  // Order the directory mounts so that more specific mounts are registered on
+  // the root router before the shorter prefixes they share. `Router.mount`
+  // also matches `prefix/<rest>` and falls through on a 404, so without this a
+  // request to `/tasks/add` could be captured by a `/tasks` mount that has a
+  // dynamic `/<taskId>` child (see #1959). Ties fall back to the route string
+  // for a stable, deterministic order.
   final directories = _getRouteDirectories(
     directory: routesDirectory,
     routesDirectory: routesDirectory,
@@ -43,7 +49,15 @@ RouteConfiguration buildRouteConfiguration(Directory directory) {
       }
     },
     onRogueRoute: rogueRoutes.add,
-  );
+  )..sort((a, b) {
+      final specificity = compareRouteDirectorySpecificity(
+        [...a.route.segments],
+        [...b.route.segments],
+      );
+      if (specificity != 0) return specificity;
+      return a.route.compareTo(b.route);
+    });
+
   final publicDirectory = Directory(path.join(directory.path, 'public'));
   final mainDartFile = File(path.join(directory.path, 'main.dart'));
 
@@ -323,7 +337,11 @@ class RouteConfiguration {
   final List<MiddlewareFile> middleware;
 
   /// List of all route directories.
-  /// Sorted from leaf nodes to root.
+  ///
+  /// Ordered by mount specificity (most specific first) so that, when the
+  /// directories are mounted on the root router in order, a longer literal
+  /// path (e.g. `/tasks/add`) is registered before a shorter prefix
+  /// (e.g. `/tasks`) that could otherwise capture it via a dynamic child.
   final List<RouteDirectory> directories;
 
   /// List of all route files.

--- a/packages/dart_frog_gen/lib/src/route_specificity.dart
+++ b/packages/dart_frog_gen/lib/src/route_specificity.dart
@@ -24,6 +24,35 @@ int compareRouteSpecificity(List<String> a, List<String> b) {
   return 0;
 }
 
+/// Compares route directories [a] and [b] to determine the order in which
+/// their routers should be mounted on the root router.
+///
+/// Unlike [compareRouteSpecificity] (which orders sibling route *files* within
+/// a single router), this orders the flat list of directory mounts registered
+/// on the root router. Because `Router.mount('/prefix', ...)` also matches
+/// `'/prefix/<rest>'` and falls through on a 404, a mount must be registered
+/// *before* any shorter prefix mount that could otherwise capture its path via
+/// a dynamic child. Each path segment is ranked so the most specific mount is
+/// registered first:
+///
+/// * a static segment (rank 2) is more specific than a shorter route that ends
+///   here (rank 1), so `'/tasks/add'` is registered before `'/tasks'`;
+/// * a shorter route that ends here (rank 1) is more specific than a dynamic
+///   segment (rank 0), so `'/books'` is registered before `'/books/<id>'`.
+///
+/// Returns a negative value if [a] should be registered before [b], a positive
+/// value if [b] should be registered before [a], and `0` if they are equally
+/// specific.
+int compareRouteDirectorySpecificity(List<String> a, List<String> b) {
+  final maxLength = a.length > b.length ? a.length : b.length;
+  for (var i = 0; i < maxLength; i++) {
+    final rankA = i < a.length ? (a[i].isDynamic ? 0 : 2) : 1;
+    final rankB = i < b.length ? (b[i].isDynamic ? 0 : 2) : 1;
+    if (rankA != rankB) return rankB - rankA;
+  }
+  return 0;
+}
+
 /// Extension that helps determine whether a route
 /// segment belongs to a dynamic route.
 extension IsDynamicRouteExtension on String {

--- a/packages/dart_frog_gen/test/src/build_route_configuration_test.dart
+++ b/packages/dart_frog_gen/test/src/build_route_configuration_test.dart
@@ -233,21 +233,6 @@ Future<void>init(InternetAddress ip,int port)async{}
     test('includes nested routes', () {
       const expected = [
         {
-          'name': '_',
-          'route': '/',
-          'middleware': [],
-          'files': [
-            {
-              'name': 'index',
-              'path': '../routes/index.dart',
-              'route': '/',
-              'file_params': [],
-              'wildcard': false,
-            }
-          ],
-          'directory_params': [],
-        },
-        {
           'name': '_echo',
           'route': '/echo',
           'middleware': [],
@@ -256,6 +241,21 @@ Future<void>init(InternetAddress ip,int port)async{}
               'name': 'echo_message',
               'path': '../routes/echo/message.dart',
               'route': '/message',
+              'file_params': [],
+              'wildcard': false,
+            }
+          ],
+          'directory_params': [],
+        },
+        {
+          'name': '_',
+          'route': '/',
+          'middleware': [],
+          'files': [
+            {
+              'name': 'index',
+              'path': '../routes/index.dart',
+              'route': '/',
               'file_params': [],
               'wildcard': false,
             }
@@ -328,21 +328,6 @@ Future<void>init(InternetAddress ip,int port)async{}
     test('includes dynamic route', () {
       const expected = [
         {
-          'name': '_',
-          'route': '/',
-          'middleware': [],
-          'files': [
-            {
-              'name': 'index',
-              'path': '../routes/index.dart',
-              'route': '/',
-              'file_params': [],
-              'wildcard': false,
-            }
-          ],
-          'directory_params': [],
-        },
-        {
           'name': '_echo',
           'route': '/echo',
           'middleware': [],
@@ -352,6 +337,21 @@ Future<void>init(InternetAddress ip,int port)async{}
               'path': '../routes/echo/[message].dart',
               'route': '/<message>',
               'file_params': ['message'],
+              'wildcard': false,
+            }
+          ],
+          'directory_params': [],
+        },
+        {
+          'name': '_',
+          'route': '/',
+          'middleware': [],
+          'files': [
+            {
+              'name': 'index',
+              'path': '../routes/index.dart',
+              'route': '/',
+              'file_params': [],
               'wildcard': false,
             }
           ],
@@ -473,21 +473,6 @@ Future<void>init(InternetAddress ip,int port)async{}
     test('includes dynamic nested directory routes w/cascading middleware', () {
       const expected = [
         {
-          'name': '_',
-          'route': '/',
-          'middleware': [],
-          'files': [
-            {
-              'name': 'index',
-              'path': '../routes/index.dart',
-              'route': '/',
-              'file_params': [],
-              'wildcard': false,
-            }
-          ],
-          'directory_params': [],
-        },
-        {
           'name': '_api',
           'route': '/api',
           'middleware': [],
@@ -496,6 +481,21 @@ Future<void>init(InternetAddress ip,int port)async{}
               'name': 'api_v1',
               'path': '../routes/api/v1.dart',
               'route': '/v1',
+              'file_params': [],
+              'wildcard': false,
+            }
+          ],
+          'directory_params': [],
+        },
+        {
+          'name': '_',
+          'route': '/',
+          'middleware': [],
+          'files': [
+            {
+              'name': 'index',
+              'path': '../routes/index.dart',
+              'route': '/',
               'file_params': [],
               'wildcard': false,
             }
@@ -1045,14 +1045,14 @@ Future<void>init(InternetAddress ip,int port)async{}
     test('detects rogue routes.', () {
       const expected = [
         {
-          'name': '_',
-          'route': '/',
+          'name': '_api_v1',
+          'route': '/api/v1',
           'middleware': [],
           'files': [
             {
-              'name': 'api',
-              'path': '../routes/api.dart',
-              'route': '/api',
+              'name': 'api_v1_hello',
+              'path': '../routes/api/v1/hello.dart',
+              'route': '/hello',
               'file_params': [],
               'wildcard': false,
             }
@@ -1082,14 +1082,14 @@ Future<void>init(InternetAddress ip,int port)async{}
           'directory_params': [],
         },
         {
-          'name': '_api_v1',
-          'route': '/api/v1',
+          'name': '_',
+          'route': '/',
           'middleware': [],
           'files': [
             {
-              'name': 'api_v1_hello',
-              'path': '../routes/api/v1/hello.dart',
-              'route': '/hello',
+              'name': 'api',
+              'path': '../routes/api.dart',
+              'route': '/api',
               'file_params': [],
               'wildcard': false,
             }
@@ -1166,21 +1166,6 @@ Future<void>init(InternetAddress ip,int port)async{}
     test('does not report rogue route when index.dart already exists', () {
       const expected = [
         {
-          'name': '_',
-          'route': '/',
-          'middleware': [],
-          'files': [
-            {
-              'name': 'api',
-              'path': '../routes/api.dart',
-              'route': '/api',
-              'file_params': [],
-              'wildcard': false,
-            }
-          ],
-          'directory_params': [],
-        },
-        {
           'name': '_api',
           'route': '/api',
           'middleware': [],
@@ -1189,6 +1174,21 @@ Future<void>init(InternetAddress ip,int port)async{}
               'name': 'api_index',
               'path': '../routes/api/index.dart',
               'route': '/',
+              'file_params': [],
+              'wildcard': false,
+            }
+          ],
+          'directory_params': [],
+        },
+        {
+          'name': '_',
+          'route': '/',
+          'middleware': [],
+          'files': [
+            {
+              'name': 'api',
+              'path': '../routes/api.dart',
+              'route': '/api',
               'file_params': [],
               'wildcard': false,
             }
@@ -1324,6 +1324,65 @@ Future<void>init(InternetAddress ip,int port)async{}
       final fileRoutes = xDir.files.map((f) => f.route).toList();
 
       expect(fileRoutes, equals(['/a', '/b']));
+    });
+
+    test(
+        'mounts static sibling directories before a dynamic sibling file '
+        'https://github.com/dart-frog-dev/dart_frog/issues/1959', () {
+      final configuration = buildRouteConfiguration(
+        createTempDir(
+          files: [
+            'routes/tasks/index.dart',
+            'routes/tasks/[taskId].dart',
+            'routes/tasks/add/index.dart',
+            'routes/tasks/start/index.dart',
+          ],
+        ),
+      );
+
+      final mountOrder = configuration.directories.map((d) => d.route).toList();
+
+      // `/tasks/add` and `/tasks/start` must be mounted before `/tasks`.
+      // Otherwise `Router.mount('/tasks', ...)` matches `/tasks/add` first and
+      // its dynamic `/<taskId>` child resolves the request with
+      // `taskId == 'add'` instead of hitting the `add/` route.
+      expect(mountOrder, equals(['/tasks/add', '/tasks/start', '/tasks']));
+      expect(
+        mountOrder.indexOf('/tasks/add'),
+        lessThan(mountOrder.indexOf('/tasks')),
+      );
+      expect(
+        mountOrder.indexOf('/tasks/start'),
+        lessThan(mountOrder.indexOf('/tasks')),
+      );
+    });
+
+    test(
+        'mounts a deeply nested static sibling before its dynamic '
+        'sibling file '
+        'https://github.com/dart-frog-dev/dart_frog/issues/1959', () {
+      final configuration = buildRouteConfiguration(
+        createTempDir(
+          files: [
+            'routes/api/v1/event/[eventId]/tasks/index.dart',
+            'routes/api/v1/event/[eventId]/tasks/[taskId].dart',
+            'routes/api/v1/event/[eventId]/tasks/add/index.dart',
+            'routes/api/v1/event/[eventId]/tasks/start/index.dart',
+          ],
+        ),
+      );
+
+      final mountOrder = configuration.directories.map((d) => d.route).toList();
+
+      const tasks = '/api/v1/event/<eventId>/tasks';
+      expect(
+        mountOrder.indexOf('$tasks/add'),
+        lessThan(mountOrder.indexOf(tasks)),
+      );
+      expect(
+        mountOrder.indexOf('$tasks/start'),
+        lessThan(mountOrder.indexOf(tasks)),
+      );
     });
   });
 


### PR DESCRIPTION
**READY**

> **Non-breaking bug fix — no public API change.** This only changes the
> *ordering* in which generated route mounts are registered on the root router,
> so requests resolve to the correct handler. No public API changes, no change
> to which routes exist or their signatures, and generated output stays
> byte-for-byte compatible aside from mount order. It does not warrant a major
> version bump.

## Description

- closes https://github.com/dart-frog-dev/dart_frog/issues/1959

`dart_frog build` / `dart_frog dev` can generate a root router where a short
prefix mount is registered before the longer literal paths nested under it.
With the layout from the issue:

```
routes/api/v1/event/[eventId]/tasks/
  index.dart          # GET  .../tasks
  [taskId].dart       # any  .../tasks/<taskId>   (flat dynamic file)
  add/index.dart      # POST .../tasks/add
  start/index.dart    # POST .../tasks/start
```

codegen emitted:

```dart
final router = Router()
  ..mount('/api/v1/event/<eventId>/tasks', ...)        // generic — first
  ..mount('/api/v1/event/<eventId>/tasks/start', ...)
  ..mount('/api/v1/event/<eventId>/tasks/add', ...);   // specific — last
```

`Router.mount('/…/tasks', …)` also matches `/…/tasks/<rest>` and falls through
on a 404, so `POST /…/tasks/add` was captured by the `tasks` router and served
by its `/<taskId>` file with `taskId == "add"` instead of hitting `add/`.

### Root cause

The order of the flat root-level mounts is the order of
`RouteConfiguration.directories`. Since #1931 (which removed the
`.reversed` in the pre-gen hooks to fix #1930), that list is the raw
depth-first order — parent directory before its children — i.e. the generic
prefix is mounted first.

#1930 and #1959 are the two mirror images of the same ordering problem:

| Issue  | Static route lives in… | Dynamic route lives in… | Correct order |
|--------|------------------------|-------------------------|---------------|
| #1930  | `/books` mount (`popular.dart`) | `/books/<id>` **mount** | `/books` before `/books/<id>` |
| #1959  | `/tasks/add` **mount** | `/tasks` mount (`[taskId].dart`) | `/tasks/add` before `/tasks` |

Neither "generic first" nor "longest first" satisfies both. The fix orders the
mounts by **segment specificity**, most specific first, where per position a
static segment out-ranks the end of a shorter route, which in turn out-ranks a
dynamic segment:

- `static (2) > end-of-path (1) > dynamic (0)`

That yields `/tasks/add` before `/tasks` (**#1959**) while keeping `/books`
before `/books/<id>` (**#1930**), because `/books` ends where `/books/<id>`
has a dynamic segment.

### Fix

`buildRouteConfiguration` now sorts `directories` with a new
`compareRouteDirectorySpecificity` comparator (ties fall back to the route
string for a stable, deterministic order). This is done in `dart_frog_gen`,
the single source both the dev-server and prod-server hooks consume, keeping
the ordering decision in one place — consistent with #1931 which made the
hooks trust the order coming out of `buildRouteConfiguration`.

Generated output after the change:

```dart
final router = Router()
  ..mount('/api/v1/event/<eventId>/tasks/add', ...)
  ..mount('/api/v1/event/<eventId>/tasks/start', ...)
  ..mount('/api/v1/event/<eventId>/tasks', ...);
```

Verified end to end (local CLI + real generated prod build):

```
POST /api/v1/event/E1/tasks/add    -> ADD task for event=E1        (was: DYNAMIC taskId=add)
POST /api/v1/event/E1/tasks/start  -> START task for event=E1      (was: DYNAMIC taskId=start)
POST /api/v1/event/E1/tasks/XYZ    -> DYNAMIC taskId=XYZ event=E1  (unchanged — real dynamic still works)
GET  /api/v1/event/E1/tasks        -> LIST tasks for event=E1      (unchanged)
```

### Note on #1958

The same ordering change also helps
[#1958](https://github.com/dart-frog-dev/dart_frog/issues/1958)
(`_middleware.dart` executed multiple times per request), but does **not** fully
close it, so this PR does not claim it.

For the minimal layout in #1958 (`routes/v2/_middleware.dart`,
`routes/v2/index.dart`, `routes/v2/person/[personId]/address.dart`) the parent
middleware went from **2 executions → 1** for a single
`GET /v2/person/123/address`: with the specificity order,
`/v2/person/<personId>` is mounted before `/v2`, so it matches first and
returns 200 without the request ever falling through the `/v2` prefix mount.

However, the root cause of #1958 is architectural. dart_frog flattens nested
routers into root-level `mount()`s, and every `Router.mount('/prefix', …)`
registers a `/prefix/<rest>` fallthrough matcher. Whenever a request has to
pass an intermediate prefix mount that 404s — e.g. add `routes/v2/person/index.dart`
so a `/v2/person` mount exists — that prefix still matches, runs the cascaded
parent middleware, 404s, and falls through, so the middleware runs twice again.
Ordering cannot avoid that; a full fix needs a change to how nested routers are
mounted, which is out of scope here.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
